### PR TITLE
feat: add Context7 MCP for live docs access

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,13 @@
         "mcp-remote",
         "https://app.fyso.dev/mcp"
       ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds Context7 as MCP server in the plugin. Skills can now query up-to-date Fyso docs via `context7.get-library-docs` without depending on static reference files.

## Test plan
- [ ] `npx @upstash/context7-mcp` installs and runs
- [ ] Skills can resolve `fyso-dev/docs` library

🤖 Generated with [Claude Code](https://claude.com/claude-code)