### PR TITLE
fix(hooks): emit valid JSON from Stop hook to fix validation error

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -f .planning/STATE.md && printf 'Antes de terminar esta sesión, verificá:\\n- ¿Quedan entidades en draft que deberían estar publicadas?\\n- ¿Quedan reglas en draft en entidades ya publicadas?\\n- ¿STATE.md refleja el estado real del tenant?\\nSi encontrás trabajo sin publicar o STATE.md desactualizado, informá al usuario en 2-3 líneas. Si todo está en orden, no digas nada.\\n' || true"
+            "command": "test -f .planning/STATE.md && printf '{\"continue\":true,\"systemMessage\":\"Antes de terminar esta sesión, verificá:\\\\n- ¿Quedan entidades en draft que deberían estar publicadas?\\\\n- ¿Quedan reglas en draft en entidades ya publicadas?\\\\n- ¿STATE.md refleja el estado real del tenant?\\\\nSi encontrás trabajo sin publicar o STATE.md desactualizado, informá al usuario en 2-3 líneas. Si todo está en orden, no digas nada.\"}' || true"
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Stop hook printed plain text to stdout, but Claude Code parses Stop hook stdout as JSON — every session end produced `Stop hook error: JSON validation failed`.
- Wrap the reminder in a `{"continue":true,"systemMessage":"..."}` envelope so stdout parses cleanly.
- Double-escape newlines (`\\\\n`) because `printf` processes escape sequences inside single quotes, otherwise real LF bytes break the JSON string.

## Background
This is a follow-up to #23, which switched `SessionStart`/`Stop` from `"type": "prompt"` to `"type": "command"` with a `.planning/STATE.md` guard so the hook only runs in Fyso projects. That fix kept the printed reminder as plain text — for `Stop`, Claude Code parses stdout, so the validation error reappeared inside Fyso projects. The `.planning/STATE.md` guard is preserved; non-Fyso projects still emit no stdout.

The same pattern exists in `SessionStart`. It was left out of this PR because the reported bug only mentions `Stop`, and the right wrapper for `SessionStart` is `hookSpecificOutput.additionalContext` (different envelope) — best handled in a focused follow-up.

## Test plan
- [x] `python3 -m json.tool hooks/hooks.json` — file is valid JSON
- [x] In a directory with `.planning/STATE.md`, the Stop command's stdout is valid JSON (`continue=true`, `systemMessage` contains the reminder with `\n` escapes preserved)
- [x] In a directory without `.planning/STATE.md`, the Stop command produces empty stdout and exit 0
- [ ] Manual: enable plugin, end a session in a Fyso project — no `Stop hook error: JSON validation failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)