### PR TITLE
feat(listen): use active Fyso session token when no FYSO_API_KEY is set

### DIFF
--- a/skills/listen/SKILL.md
+++ b/skills/listen/SKILL.md
@@ -13,7 +13,7 @@ Connect this Claude Code session to the Fyso real-time event stream. Events from
 
 - Claude Code v2.1.80 or later
 - `bun` installed (`bun --version` to check, https://bun.sh if not)
-- A valid Fyso API key or JWT for the target tenant
+- An authenticated Fyso session — either an `FYSO_API_KEY` env var, or a saved plugin session at `~/.fyso/config.json` (created by `/sync-team` or any other Fyso login flow)
 - The Fyso plugin installed (`/plugin install fyso@fyso-marketplace`)
 
 ## Usage
@@ -52,10 +52,13 @@ Collect the following values. Use what's already available before asking the use
 | Value | Source (in priority order) |
 |-------|---------------------------|
 | `FYSO_TENANT_SLUG` | `--tenant` arg → active session tenant (from `select_tenant`) → ask user |
-| `FYSO_API_KEY` | env var `FYSO_API_KEY` → ask user |
-| `FYSO_API_URL` | env var `FYSO_API_URL` → default `https://app.fyso.dev` |
+| `FYSO_API_KEY` | env var `FYSO_API_KEY` → `token` field in `~/.fyso/config.json` (active plugin session) → ask user |
+| `FYSO_API_URL` | env var `FYSO_API_URL` → `api_url` field in `~/.fyso/config.json` → default `https://app.fyso.dev` |
 | `FYSO_ENTITIES` | `--entities` arg → env var `FYSO_ENTITIES` → empty (all events) |
 | `FYSO_AGENT_NAME` | `--name` arg → `.fyso-agent` file → derive from directory name → ask user to confirm |
+
+**Active plugin session lookup:**
+Read `~/.fyso/config.json` once and reuse it for both `FYSO_API_KEY` and `FYSO_API_URL`. The file is JSON with shape `{ "token": "...", "tenant_id": "...", "api_url": "...", ... }` and is written by the Fyso plugin during login (e.g. via `/sync-team`). If the file does not exist or the `token` field is empty, fall through to the next source. Do NOT prompt the user for an API key when a saved session token is available — the SSE endpoint accepts the same bearer token used by the plugin.
 
 **Agent name resolution when not provided:**
 If `--name` is not given and no `.fyso-agent` file exists, derive a suggested name from the current directory basename (e.g. `~/agents/cero/` → suggest `cero`, `~/work/fyso/coordinator` → suggest `coordinator`). Present the suggestion to the user and let them confirm or change it. Do NOT default to anonymous — always suggest a name so messaging works out of the box.
@@ -63,8 +66,8 @@ If `--name` is not given and no `.fyso-agent` file exists, derive a suggested na
 ### Step 2: Validate
 
 - `FYSO_TENANT_SLUG` must not be empty
-- `FYSO_API_KEY` must not be empty
-- If either is missing, tell the user what's needed and stop
+- `FYSO_API_KEY` must not be empty. If neither the env var nor `~/.fyso/config.json` has a usable token, tell the user to either export `FYSO_API_KEY` or run the Fyso plugin login (e.g. `/sync-team`) to create `~/.fyso/config.json`, then stop.
+- If `FYSO_TENANT_SLUG` is missing, tell the user what's needed and stop.
 
 ### Step 3: Find the channel server path
 
@@ -360,7 +363,7 @@ Complete chain without external intervention.
 
 | Problem | Solution |
 |---------|----------|
-| Auth failed (401) | Check `FYSO_API_KEY` in `~/.claude/channels/fyso/.env` |
+| Auth failed (401) | Check `FYSO_API_KEY` in `.mcp.json` for the `fyso-channel` server. If it was sourced from `~/.fyso/config.json`, the saved session may have expired — re-run the Fyso plugin login (e.g. `/sync-team`) to refresh the token and re-run `/fyso:listen`. |
 | Tenant not found (404) | Check `FYSO_TENANT_SLUG` |
 | Channel not registering | Make sure `bun` is installed and you used `--dangerously-load-development-channels` |
 | No events arriving | Verify entity filter isn't too narrow; try without `--entities` |


### PR DESCRIPTION
## Summary
- `/fyso:listen` no longer prompts the user for `FYSO_API_KEY` when an authenticated Fyso plugin session already exists.
- The skill now falls back to the `token` (and `api_url`) saved at `~/.fyso/config.json` by `/sync-team` (or any other plugin login flow) before asking the user.
- Updated the Requirements, Step 1 resolution table, Step 2 validation, and the 401 troubleshooting hint in `skills/listen/SKILL.md` to reflect the new lookup chain.

## Background
Per the linked task, requiring users to manually create an API key when they are already logged in through the plugin is redundant. The SSE endpoint accepts the same bearer token the plugin uses, so the active session token is sufficient.

> Depends on `fyso_backend` already accepting JWT/session tokens on the SSE endpoint.

## Test plan
- [ ] With `~/.fyso/config.json` present and a valid `token`, run `/fyso:listen --name myagent` and confirm the resulting `.mcp.json` uses that token as `FYSO_API_KEY` without prompting.
- [ ] With `FYSO_API_KEY` exported, confirm the env var still wins over the saved session.
- [ ] With neither source available, confirm the skill stops with the new guidance pointing to `/sync-team`.
- [ ] Confirm that running the channel server with the session-derived key successfully connects to the SSE stream and starts receiving events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)