### PR TITLE
docs(ui-skill): teach generated UI to use REST envelope + resolve_depth

### DIFF
--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -514,12 +514,14 @@ Write `.planning/UI-CONTRACTS.md`:
 
 ## Authentication Endpoints
 
+> All responses are wrapped in `{ success, data }` — `Response:` below shows the **unwrapped** `data` payload.
+
 ### Login
 ```
 POST /api/auth/tenant/login
 Headers: X-Tenant-ID: {slug}
 Body: { email, password }
-Response: { token, user: { id, email, name, role } }
+Response data: { token, user: { id, email, name, role } }
 ```
 
 ### Register (if self-registration)
@@ -527,7 +529,7 @@ Response: { token, user: { id, email, name, role } }
 POST /api/auth/tenant/register
 Headers: X-Tenant-ID: {slug}
 Body: { email, password, name }
-Response: { token, user: { id, email, name, role } }
+Response data: { token, user: { id, email, name, role } }
 ```
 
 ### Logout
@@ -540,7 +542,7 @@ Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
 ```
 GET /api/auth/tenant/me
 Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
-Response: { id, email, name, role, permissions }
+Response data: { id, email, name, role, permissions }
 ```
 
 ## Data Endpoints
@@ -556,29 +558,33 @@ Response: { id, email, name, role, permissions }
 
 **List:**
 ```
-GET /api/entities/{entity}/records?page=1&limit=20&sort=name&order=asc
+GET /api/entities/{entity}/records?page=1&limit=20&sort=name&order=asc&resolve_depth=1
 Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
-Response: { data: Record[], total, page, limit, totalPages }
+Response data: { items: Record[], total, page, limit, totalPages }
 ```
+
+Read records from `data.items` — NOT `data.data`. Pass `resolve_depth=1` for entities with relations so related fields become nested objects (with names) instead of UUID strings.
 
 **Get One:**
 ```
 GET /api/entities/{entity}/records/{id}
-Response: { id, entityId, name, data: { ...fields }, createdAt, updatedAt }
+Response data: { id, entityId, ...fields, createdAt, updatedAt }
 ```
+
+Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`. `resolve_depth` is not supported on this endpoint — use the list endpoint with an id filter if you need expanded relations.
 
 **Create:**
 ```
 POST /api/entities/{entity}/records
 Body: { field1: value1, field2: value2 }
-Response: { id, data: { ...fields } }
+Response data: { id, ...fields }
 ```
 
 **Update:**
 ```
 PUT /api/entities/{entity}/records/{id}
 Body: { field1: newValue }
-Response: { id, data: { ...fields } }
+Response data: { id, ...fields }
 ```
 
 **Delete:**
@@ -586,6 +592,8 @@ Response: { id, data: { ...fields } }
 DELETE /api/entities/{entity}/records/{id}
 Response: { success: true }
 ```
+
+**Filters:** the REST API supports AND-only compound filters via `?filters=field1 = value AND field2 > N`. For OR conditions, fetch the AND subset and filter `data.items` client-side.
 
 ## Role → Permission Matrix
 
@@ -672,13 +680,21 @@ The generated UI uses:
 - **State:** React context for auth + custom hooks for data fetching
 - **Icons:** Lucide React
 
-**Do NOT use `@fyso/ui`.** Generate custom components that call the Fyso API directly:
+**Do NOT use `@fyso/ui`.** Generate custom components that call the Fyso API directly.
+
+**REST envelope contract (must follow — see `reference/auth-patterns.md` → "REST API Response Patterns"):**
+- Every response is `{ success: boolean, data?: ..., error?: { code, message } }`. Always unwrap `json.data` before returning to callers.
+- List endpoints return `data: { items, total, page, limit, totalPages }` — read the array from `data.items`, NOT `data.data` and NOT `data.records`.
+- Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`.
+- For list views of entities with relations, always pass `resolve_depth=1` so the UI renders related names instead of UUIDs.
+- The REST API only supports AND filters; for OR, fetch with AND and filter `data.items` client-side.
+
 ```ts
 // src/lib/api.ts
 const BASE = import.meta.env.PUBLIC_API_URL   // e.g. https://app.fyso.dev
 const TENANT = import.meta.env.PUBLIC_TENANT  // tenant slug
 
-async function apiFetch(path: string, options: RequestInit = {}, token?: string) {
+async function apiFetch<T = unknown>(path: string, options: RequestInit = {}, token?: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     ...options,
     headers: {
@@ -688,24 +704,61 @@ async function apiFetch(path: string, options: RequestInit = {}, token?: string)
       ...options.headers,
     },
   })
-  if (!res.ok) throw await res.json()
-  return res.json()
+  const json = await res.json()
+  if (!res.ok || json.success === false) {
+    throw new Error(json.error?.message ?? json.error?.code ?? `HTTP ${res.status}`)
+  }
+  // Unwrap the { success, data } envelope so callers always see plain data.
+  return json.data as T
+}
+
+// Build the query string for list calls. Pass `resolveDepth: 1` whenever
+// the entity has relations and the UI needs the related names, otherwise
+// the UI will render UUIDs.
+function listQuery(params: { page?: number; limit?: number; sort?: string; order?: 'asc' | 'desc'; search?: string; filters?: string; resolveDepth?: number } = {}) {
+  const qs = new URLSearchParams()
+  if (params.page) qs.set('page', String(params.page))
+  if (params.limit) qs.set('limit', String(params.limit))
+  if (params.sort) qs.set('sort', params.sort)
+  if (params.order) qs.set('order', params.order)
+  if (params.search) qs.set('search', params.search)
+  if (params.filters) qs.set('filters', params.filters)
+  if (params.resolveDepth) qs.set('resolve_depth', String(params.resolveDepth))
+  return qs.toString()
+}
+
+export interface ListResponse<R = Record<string, unknown>> {
+  items: R[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
 }
 
 export const api = {
   login: (email: string, password: string) =>
-    apiFetch('/api/auth/tenant/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
-  me: (token: string) => apiFetch('/api/auth/tenant/me', {}, token),
-  list: (entity: string, token: string, params = '') =>
-    apiFetch(`/api/entities/${entity}/records?${params}`, {}, token),
-  get: (entity: string, id: string, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, {}, token),
-  create: (entity: string, data: object, token: string) =>
-    apiFetch(`/api/entities/${entity}/records`, { method: 'POST', body: JSON.stringify(data) }, token),
-  update: (entity: string, id: string, data: object, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, { method: 'PUT', body: JSON.stringify(data) }, token),
+    apiFetch<{ token: string; user: User }>(
+      '/api/auth/tenant/login',
+      { method: 'POST', body: JSON.stringify({ email, password }) },
+    ),
+  me: (token: string) => apiFetch<User>('/api/auth/tenant/me', {}, token),
+
+  // Returns { items, total, page, limit, totalPages } — already unwrapped from
+  // the { success, data } envelope by apiFetch.
+  list: <R = Record<string, unknown>>(entity: string, token: string, params: Parameters<typeof listQuery>[0] = {}) =>
+    apiFetch<ListResponse<R>>(`/api/entities/${entity}/records?${listQuery(params)}`, {}, token),
+
+  get: <R = Record<string, unknown>>(entity: string, id: string, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records/${id}`, {}, token),
+
+  create: <R = Record<string, unknown>>(entity: string, data: object, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records`, { method: 'POST', body: JSON.stringify(data) }, token),
+
+  update: <R = Record<string, unknown>>(entity: string, id: string, data: object, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records/${id}`, { method: 'PUT', body: JSON.stringify(data) }, token),
+
   remove: (entity: string, id: string, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, { method: 'DELETE' }, token),
+    apiFetch<{ id: string }>(`/api/entities/${entity}/records/${id}`, { method: 'DELETE' }, token),
 }
 ```
 
@@ -817,6 +870,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [token])
 
   const login = async (email: string, password: string) => {
+    // api.login returns the unwrapped { token, user } payload (envelope handled in api.ts).
     const { token: t, user: u } = await api.login(email, password)
     localStorage.setItem('fyso_token', t)
     setToken(t); setUser(u)
@@ -831,16 +885,21 @@ export const useAuth = () => useContext(AuthContext)!
 **Entity list with pagination:**
 ```tsx
 // EntityList.tsx
-export function EntityList({ entity }: { entity: string }) {
-  const { token, user } = useAuth()
-  const [records, setRecords] = useState([])
+//
+// Pass `hasRelations` for entities whose schema has at least one relation field
+// (query `get_entity_schema` during build to detect this). When true we request
+// `resolve_depth=1` so the table can show related names instead of UUIDs.
+export function EntityList({ entity, hasRelations }: { entity: string; hasRelations?: boolean }) {
+  const { token } = useAuth()
+  const [records, setRecords] = useState<Record<string, unknown>[]>([])
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
 
   useEffect(() => {
-    api.list(entity, token!, `page=${page}&limit=20`)
-      .then(r => { setRecords(r.data); setTotal(r.total) })
-  }, [entity, page, token])
+    // api.list returns the already-unwrapped { items, total, page, limit, totalPages } payload.
+    api.list(entity, token!, { page, limit: 20, resolveDepth: hasRelations ? 1 : undefined })
+      .then(r => { setRecords(r.items); setTotal(r.total) })
+  }, [entity, page, token, hasRelations])
 
   return (
     <div>
@@ -849,6 +908,15 @@ export function EntityList({ entity }: { entity: string }) {
     </div>
   )
 }
+```
+
+**Reading record fields:** records are flat. To show a related entity's name, request `resolveDepth: 1` and read `record.{relationKey}.{nameField}` (e.g. `record.cliente.nombre`). Without `resolve_depth` the relation field is a UUID string.
+
+**Client-side OR filtering:** the REST API supports AND-only compound filters. For OR conditions, fetch the AND subset on the server and filter `r.items` in the component:
+
+```tsx
+const r = await api.list('facturas', token!, { filters: 'estado = pendiente' })
+const visible = r.items.filter(f => f.estado === 'pendiente' || f.estado === 'vencida')
 ```
 
 **Create/edit form:**

--- a/skills/ui/templates/api-contracts.md
+++ b/skills/ui/templates/api-contracts.md
@@ -54,6 +54,8 @@ X-Tenant-ID: {tenant-slug}
 }
 ```
 
+> **Envelope rule (applies to ALL responses below):** every REST response is `{ success: boolean, data?: ..., error?: ... }`. Always unwrap `json.data` before use. See `reference/auth-patterns.md` → "REST API Response Patterns".
+
 ### Register (if self-registration enabled)
 
 ```http
@@ -116,22 +118,20 @@ X-Tenant-ID: {tenant-slug}
 |-------|-----|------|----------|--------|---------|-------|
 | {display} | {key} | {type} | {yes/no} | {yes/no} | {value} | {notes} |
 
-**Record shape:**
+**Record shape (flat, since v1.26.0):**
 ```json
 {
   "id": "uuid",
   "entityId": "uuid",
-  "name": "{value of name field}",
-  "data": {
-    "{field_key_1}": "{value}",
-    "{field_key_2}": "{value}"
-  },
+  "{field_key_1}": "{value}",
+  "{field_key_2}": "{value}",
+  "{relation_key}": "uuid-of-related-record",
   "createdAt": "ISO-8601",
   "updatedAt": "ISO-8601"
 }
 ```
 
-**IMPORTANT:** Entity field values are in `record.data.{fieldKey}`, NOT `record.{fieldKey}`.
+**IMPORTANT:** Record fields are flat — read them as `record.{fieldKey}`. There is no `record.data` nesting (the old nested format was removed in v1.26.0).
 
 **List:**
 ```http
@@ -140,14 +140,33 @@ X-API-Key: {token}
 X-Tenant-ID: {tenant-slug}
 ```
 
-Response: `{ data: { data: Record[], total, page, limit, totalPages } }`
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "items": [ { "id": "...", "...": "..." } ],
+    "total": 42,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3
+  }
+}
+```
+
+> Read the array from `json.data.items` — NOT `json.data` and NOT `json.data.data`.
 
 **Get One:**
 ```http
 GET /api/entities/{entity}/records/{id}
 ```
 
-Response: `{ data: Record }`
+Response:
+```json
+{ "success": true, "data": { "id": "...", "...": "..." } }
+```
+
+> Read the record from `json.data`. `resolve_depth` is NOT supported here — use the list endpoint with `?filters=id = {id}&resolve_depth=1` if you need expanded relations.
 
 **Create:**
 ```http
@@ -157,7 +176,7 @@ Content-Type: application/json
 { "{field_key_1}": "value1", "{field_key_2}": "value2" }
 ```
 
-Response 201: `{ data: Record }`
+Response 201: `{ "success": true, "data": Record }`
 
 **Update:**
 ```http
@@ -167,29 +186,33 @@ Content-Type: application/json
 { "{field_key}": "new_value" }
 ```
 
-Response: `{ data: Record }`
+Response: `{ "success": true, "data": Record }`
 
 **Delete:**
 ```http
 DELETE /api/entities/{entity}/records/{id}
 ```
 
-Response: `{ success: true }`
+Response: `{ "success": true }`
 
 **Search:**
 ```http
 GET /api/entities/{entity}/records?search={query}
 ```
 
-**Filters:**
+**Filters (server-side, AND only):**
 ```http
-GET /api/entities/{entity}/records?filter.{field}={value}
+GET /api/entities/{entity}/records?filters=estado = activo AND monto > 1000
 ```
 
-**Expand relations:**
+For OR conditions, fetch with the AND subset and filter `json.data.items` client-side.
+
+**Expand relations (list endpoint only):**
 ```http
-GET /api/entities/{entity}/records?resolve=true
+GET /api/entities/{entity}/records?resolve_depth=1
 ```
+
+When `resolve_depth=1`, every relation field on each item becomes a full nested object instead of a UUID string — use this whenever the UI needs to show a related entity's name (so you don't render UUIDs). For entities listed below with relations, ALWAYS request `resolve_depth=1` on list views.
 
 ---
 


### PR DESCRIPTION
## Summary
- POS-frontend feedback flagged that `/fyso:ui`-generated code was looking for `data.data`, `record.data.fieldKey`, and skipping `resolve_depth`, so lists came back empty and tables rendered UUIDs.
- Update `skills/ui/SKILL.md` so the generated `src/lib/api.ts` and `EntityList` example unwrap the `{ success, data }` envelope, return `{ items, total, ... }` on lists, treat records as flat (v1.26.0+), and accept a `resolveDepth` option that maps to `?resolve_depth=1`.
- Update `skills/ui/templates/api-contracts.md` so the documented entity contracts use the real shapes (`json.data.items`, flat record, `resolve_depth=1` on lists, no `resolve_depth` on get-one) and call out client-side OR filtering as the workaround for the AND-only filter API.

The deeper REST patterns reference (`reference/auth-patterns.md`) was already updated; this PR pulls those rules into the skill's own code-generation instructions and the contract template that gets copied into every generated `UI-CONTRACTS.md`.

## Test plan
- [ ] Run `/fyso:ui infer` against a sample tenant with relations and confirm the generated `api.ts` unwraps the envelope and the list view passes `resolve_depth=1`.
- [ ] Confirm the generated `UI-CONTRACTS.md` shows `data.items`, flat record fields, and the OR-filter caveat.
- [ ] Spot-check that a list with a relation column renders the related name (not a UUID) end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)