### PR TITLE
docs: REST/UI patterns for UI skill + domain frontend flows

### DIFF
--- a/skills/plan/reference/domain-patterns.md
+++ b/skills/plan/reference/domain-patterns.md
@@ -16,6 +16,24 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Validate: email format
 - Validate: fecha sesion not in past
 
+### Frontend Flow
+
+**Journey: Schedule a session**
+1. Pick patient → `GET /api/entities/pacientes/records?filters=activo = true&sort=nombre&limit=50`
+2. Pick professional → `GET /api/entities/profesionales/records?filters=activo = true`
+3. Submit form → `POST /api/entities/sesiones/records` with `{ paciente, profesional, fecha, hora, duracion_min, estado: "programada", monto }`
+4. Show upcoming sessions with names → `GET /api/entities/sesiones/records?resolve_depth=1&filters=fecha >= <today>&sort=fecha`
+
+**Journey: Bill a session**
+1. Create factura in `borrador` → `POST /api/entities/facturas/records` with `{ paciente, sesion, fecha, subtotal, estado: "borrador" }`
+2. Refetch to display computed `iva` and `total` (with related paciente/sesion) → `GET /api/entities/facturas/records/:id?resolve_depth=1`
+3. Mark emitted → `PUT /api/entities/facturas/records/:id` with `{ estado: "emitida" }`
+
+**Pitfalls:**
+- Without `?resolve_depth=1`, the sessions list shows `paciente` and `profesional` as UUIDs.
+- `factura.iva` and `factura.total` are computed by rules — render them read-only and refetch after `POST` instead of computing in the form.
+- "Past date" rejection comes back as `BUSINESS_RULE_ERROR` — surface the message inline on the `fecha` field.
+
 ---
 
 ## Retail / Store
@@ -33,6 +51,23 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Validate: cantidad > 0
 - Validate: stock >= 0
 
+### Frontend Flow
+
+**Journey: Build and close a sale**
+1. Search products to add → `GET /api/entities/productos/records?filters=activo = true AND nombre contains <q>&limit=20`
+2. Create venta header → `POST /api/entities/ventas/records` with `{ cliente, fecha, estado: "pendiente", metodo_pago, descuento }`
+3. For each line → `POST /api/entities/detalle_venta/records` with `{ venta, producto, cantidad, precio_unitario }` (`subtotal` computed by rule)
+4. Refetch venta to read recomputed total → `GET /api/entities/ventas/records/:id`
+5. Close → `PUT /api/entities/ventas/records/:id` with `{ estado: "completada" }`
+
+**Journey: Show cart with product names**
+- `GET /api/entities/detalle_venta/records?filters=venta = <id>&resolve_depth=1` — read `row.producto.nombre` after resolve.
+
+**Pitfalls:**
+- `bajo_stock` is computed and not filterable server-side — fetch products and flag low stock client-side from `stock` and `stock_minimo`.
+- `venta.total` is recomputed by rules after each line insert/update; refetch instead of summing in the UI to stay consistent with the server.
+- Server filters are AND-only. To show "active OR featured" fetch the active subset and union client-side.
+
 ---
 
 ## Services / Consulting
@@ -49,6 +84,23 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Validate: fecha_fin >= fecha_inicio
 - Validate: horas_estimadas > 0
 
+### Frontend Flow
+
+**Journey: Track project hours**
+1. List active projects with client name → `GET /api/entities/proyectos/records?filters=estado = activo&resolve_depth=1`
+2. Open a project → list its tasks → `GET /api/entities/tareas/records?filters=proyecto = <id>&sort=createdAt`
+3. Update a task → `PUT /api/entities/tareas/records/:id` with `{ horas_reales, estado: "completada" }`
+4. Refetch project to show updated `horas_total` → `GET /api/entities/proyectos/records/:id`
+
+**Journey: Issue project invoice**
+1. `POST /api/entities/facturas/records` with `{ cliente, proyecto, fecha, subtotal, estado: "borrador" }`
+2. Refetch to read computed `iva` / `total` → `GET /api/entities/facturas/records/:id`
+
+**Pitfalls:**
+- `proyecto.horas_total` only updates via the `after_save` action on `tareas`. The project record returned right before the action runs may still be stale — refetch after each task save.
+- Tasks list won't show project name without `resolve_depth=1` (or render against the in-memory project object you already have).
+- Validate `fecha_fin >= fecha_inicio` client-side; server rejects with `BUSINESS_RULE_ERROR` but immediate UX is better.
+
 ---
 
 ## Restaurant
@@ -64,6 +116,34 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Validate: cantidad > 0
 - Validate: plato disponible == true
 
+### Frontend Flow
+
+**Journey: Open a table and take an order**
+1. Pick a free table → `GET /api/entities/mesas/records?filters=estado = libre&sort=numero`
+2. Create pedido → `POST /api/entities/pedidos/records` with `{ mesa, fecha, hora, estado: "abierto", mesero }`
+3. Mark mesa occupied → `PUT /api/entities/mesas/records/:mesa_id` with `{ estado: "ocupada" }`
+4. Browse menu — only available items → `GET /api/entities/platos/records?filters=disponible = true&sort=categoria`
+5. For each item → `POST /api/entities/detalle_pedido/records` with `{ pedido, plato, cantidad, precio_unitario, notas }` (`subtotal` computed by rule)
+
+**Journey: Add items to an existing order**
+1. Find the open pedido for the table → `GET /api/entities/pedidos/records?filters=mesa = <id> AND estado != cerrado&resolve_depth=1`
+2. Show current lines with plato names → `GET /api/entities/detalle_pedido/records?filters=pedido = <id>&resolve_depth=1` — read `row.plato.nombre`
+3. Append more lines → `POST /api/entities/detalle_pedido/records`
+4. Refetch pedido to display the recomputed total → `GET /api/entities/pedidos/records/:id`
+
+**Journey: Pay and close**
+1. Refetch pedido for the outstanding total.
+2. Create pago → `POST /api/entities/pagos/records` with `{ pedido, monto, metodo, fecha }` (assumes a `pagos` entity in your tenant — reuse the pattern from Freelancer if you need to model it).
+3. Close pedido → `PUT /api/entities/pedidos/records/:id` with `{ estado: "cerrado" }`
+4. Free the mesa → `PUT /api/entities/mesas/records/:mesa_id` with `{ estado: "libre" }`
+
+**Pitfalls:**
+- Filter the menu by `disponible = true` server-side, not client-side — clients should not see unavailable items at all.
+- `detalle_pedido.plato` is a UUID. Always pass `?resolve_depth=1` when listing details so kitchen tickets show plato names.
+- The three writes "create pago → update pedido → update mesa" are not transactional. Run them sequentially, abort on first error, and surface a partial-state warning to the cashier.
+- "Still open" needs `estado != cerrado`. For "abierto OR en_preparacion" fetch the AND-compatible subset and union client-side (server filters are AND-only).
+- Don't send `total` on pedido create — let the rule recompute it from detalle subtotals after each line.
+
 ---
 
 ## Repair Shop / Workshop
@@ -78,6 +158,20 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Compute: detalle subtotal = cantidad * precio_unitario
 - Validate: stock >= 0
 - Transform: codigo → uppercase
+
+### Frontend Flow
+
+**Journey: Intake a job**
+1. Find or create cliente → `GET /api/entities/clientes/records?filters=telefono contains <q>` then `POST /api/entities/clientes/records` if no match.
+2. Create trabajo → `POST /api/entities/trabajos/records` with `{ cliente, equipo, descripcion, fecha_ingreso, estado: "recibido", costo_estimado }`
+3. As parts are added → `POST /api/entities/detalle_trabajo/records` with `{ trabajo, repuesto, cantidad, precio_unitario }`
+4. Advance status → `PUT /api/entities/trabajos/records/:id` with `{ estado: "diagnostico" | "reparando" | "listo" | "entregado" }`
+5. Show line items with part names → `GET /api/entities/detalle_trabajo/records?filters=trabajo = <id>&resolve_depth=1`
+
+**Pitfalls:**
+- `repuesto.codigo` is auto-uppercased by a transform. After save, refresh the form from the response — don't trust the value still in form state.
+- Stock decrement is not wired by default. If the UI needs to show "stock left" after a part is consumed, add a rule; do not decrement client-side.
+- `detalle_trabajo` listing without `resolve_depth=1` shows repuesto UUIDs.
 
 ---
 
@@ -95,6 +189,23 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - Validate: cantidad > 0 (movimientos)
 - Validate: stock >= 0
 
+### Frontend Flow
+
+**Journey: Receive a purchase**
+1. List proveedores → `GET /api/entities/proveedores/records?sort=nombre`
+2. Create compra header → `POST /api/entities/compras/records` with `{ proveedor, fecha, estado: "pendiente", total }`
+3. For each item received → `POST /api/entities/movimientos/records` with `{ producto, tipo: "entrada", cantidad, fecha, motivo: "compra", referencia: <compra_id> }`
+4. Mark compra received → `PUT /api/entities/compras/records/:id` with `{ estado: "recibida" }`
+5. Show movement history with product names → `GET /api/entities/movimientos/records?filters=referencia = <compra_id>&resolve_depth=1`
+
+**Journey: Low-stock dashboard**
+- `GET /api/entities/productos/records?limit=200` then filter `items.filter(p => p.stock < p.stock_minimo)` client-side.
+
+**Pitfalls:**
+- `bajo_stock` is computed and not stored, so it cannot be filtered server-side. Fetch with a broader filter and compute the alert client-side.
+- The platform does not roll back stock on a deleted movimiento — communicate "ajuste" semantics to the operator and prefer a corrective movement over a delete.
+- Movements list without `resolve_depth=1` shows producto UUIDs.
+
 ---
 
 ## Freelancer / Solo
@@ -108,6 +219,24 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 ### Common Rules
 - Compute: factura total = subtotal + iva, iva = subtotal * 0.21
 - Validate: monto pago > 0
+
+### Frontend Flow
+
+**Journey: Invoice and collect**
+1. List active proyectos → `GET /api/entities/proyectos/records?filters=estado = activo&resolve_depth=1`
+2. Create factura → `POST /api/entities/facturas/records` with `{ cliente, proyecto, numero, fecha, subtotal, estado: "borrador" }` (`iva` and `total` are computed)
+3. Refetch to display computed totals → `GET /api/entities/facturas/records/:id`
+4. Send → `PUT /api/entities/facturas/records/:id` with `{ estado: "enviada" }`
+5. On payment, create pago → `POST /api/entities/pagos/records` with `{ factura, fecha, monto, metodo }`
+6. Mark factura paid → `PUT /api/entities/facturas/records/:id` with `{ estado: "pagada" }`
+
+**Journey: Vencidas dashboard**
+- `GET /api/entities/facturas/records?filters=estado = enviada&resolve_depth=1` then compute `fecha < today` client-side.
+
+**Pitfalls:**
+- `factura.numero` is `unique` — surface 400/`VALIDATION_ERROR` to the user instead of swallowing it.
+- There is no date-arithmetic filter. "Vencidas" must be derived client-side from `fecha` and today's date.
+- Pago is not auto-applied to factura. The two writes (create pago → update factura.estado) are independent — show progress and roll back if step 2 fails.
 
 ---
 
@@ -131,3 +260,13 @@ Leave optional: notes, descriptions, secondary contact info.
 ### Relations
 Always specify `displayField` — usually "nombre" or "name".
 Relations are always optional unless explicitly required.
+
+### Frontend / REST Conventions (cross-cutting)
+
+These apply to every Frontend Flow above — keep them in mind when generating UI:
+
+- **Envelope:** every response is `{ success, data?, error? }`. Read list arrays from `data.items` (not `data.records`, not `data.data`). Records are flat — `record.fieldKey`, never `record.data.fieldKey`.
+- **`resolve_depth`:** required whenever the UI needs related names instead of UUIDs. Pass `?resolve_depth=1` on list endpoints (max 2) and on single-record `GET /records/:id` (max 3). Without it, relation fields come back as UUID strings.
+- **AND-only filters:** `?filters=` joins with `AND`. For OR conditions (e.g. "abierto OR en_preparacion"), fetch the AND-compatible subset and union client-side.
+- **Computed fields:** anything driven by a Compute rule (`total`, `iva`, `subtotal`, `bajo_stock`, `horas_total`, `margen`, `edad`) must be rendered read-only in forms and refetched after writes — do not duplicate the formula in the UI.
+- **Multi-entity transitions** (e.g. pay → close pedido → free mesa, create pago → mark factura pagada): the platform does not run them in a transaction. Sequence the writes, abort on first failure, and surface a partial-state warning rather than pretending the whole flow succeeded.

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -514,12 +514,14 @@ Write `.planning/UI-CONTRACTS.md`:
 
 ## Authentication Endpoints
 
+> All responses are wrapped in `{ success, data }` — `Response:` below shows the **unwrapped** `data` payload.
+
 ### Login
 ```
 POST /api/auth/tenant/login
 Headers: X-Tenant-ID: {slug}
 Body: { email, password }
-Response: { token, user: { id, email, name, role } }
+Response data: { token, user: { id, email, name, role } }
 ```
 
 ### Register (if self-registration)
@@ -527,7 +529,7 @@ Response: { token, user: { id, email, name, role } }
 POST /api/auth/tenant/register
 Headers: X-Tenant-ID: {slug}
 Body: { email, password, name }
-Response: { token, user: { id, email, name, role } }
+Response data: { token, user: { id, email, name, role } }
 ```
 
 ### Logout
@@ -540,7 +542,7 @@ Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
 ```
 GET /api/auth/tenant/me
 Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
-Response: { id, email, name, role, permissions }
+Response data: { id, email, name, role, permissions }
 ```
 
 ## Data Endpoints
@@ -556,29 +558,33 @@ Response: { id, email, name, role, permissions }
 
 **List:**
 ```
-GET /api/entities/{entity}/records?page=1&limit=20&sort=name&order=asc
+GET /api/entities/{entity}/records?page=1&limit=20&sort=name&order=asc&resolve_depth=1
 Headers: X-API-Key: {token}, X-Tenant-ID: {slug}
-Response: { data: Record[], total, page, limit, totalPages }
+Response data: { items: Record[], total, page, limit, totalPages }
 ```
+
+Read records from `data.items` — NOT `data.data`. Pass `resolve_depth=1` for entities with relations so related fields become nested objects (with names) instead of UUID strings.
 
 **Get One:**
 ```
 GET /api/entities/{entity}/records/{id}
-Response: { id, entityId, name, data: { ...fields }, createdAt, updatedAt }
+Response data: { id, entityId, ...fields, createdAt, updatedAt }
 ```
+
+Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`. `resolve_depth` is not supported on this endpoint — use the list endpoint with an id filter if you need expanded relations.
 
 **Create:**
 ```
 POST /api/entities/{entity}/records
 Body: { field1: value1, field2: value2 }
-Response: { id, data: { ...fields } }
+Response data: { id, ...fields }
 ```
 
 **Update:**
 ```
 PUT /api/entities/{entity}/records/{id}
 Body: { field1: newValue }
-Response: { id, data: { ...fields } }
+Response data: { id, ...fields }
 ```
 
 **Delete:**
@@ -586,6 +592,8 @@ Response: { id, data: { ...fields } }
 DELETE /api/entities/{entity}/records/{id}
 Response: { success: true }
 ```
+
+**Filters:** the REST API supports AND-only compound filters via `?filters=field1 = value AND field2 > N`. For OR conditions, fetch the AND subset and filter `data.items` client-side.
 
 ## Role → Permission Matrix
 
@@ -672,13 +680,21 @@ The generated UI uses:
 - **State:** React context for auth + custom hooks for data fetching
 - **Icons:** Lucide React
 
-**Do NOT use `@fyso/ui`.** Generate custom components that call the Fyso API directly:
+**Do NOT use `@fyso/ui`.** Generate custom components that call the Fyso API directly.
+
+**REST envelope contract (must follow — see `reference/auth-patterns.md` → "REST API Response Patterns"):**
+- Every response is `{ success: boolean, data?: ..., error?: { code, message } }`. Always unwrap `json.data` before returning to callers.
+- List endpoints return `data: { items, total, page, limit, totalPages }` — read the array from `data.items`, NOT `data.data` and NOT `data.records`.
+- Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`.
+- For list views of entities with relations, always pass `resolve_depth=1` so the UI renders related names instead of UUIDs.
+- The REST API only supports AND filters; for OR, fetch with AND and filter `data.items` client-side.
+
 ```ts
 // src/lib/api.ts
 const BASE = import.meta.env.PUBLIC_API_URL   // e.g. https://app.fyso.dev
 const TENANT = import.meta.env.PUBLIC_TENANT  // tenant slug
 
-async function apiFetch(path: string, options: RequestInit = {}, token?: string) {
+async function apiFetch<T = unknown>(path: string, options: RequestInit = {}, token?: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     ...options,
     headers: {
@@ -688,24 +704,61 @@ async function apiFetch(path: string, options: RequestInit = {}, token?: string)
       ...options.headers,
     },
   })
-  if (!res.ok) throw await res.json()
-  return res.json()
+  const json = await res.json()
+  if (!res.ok || json.success === false) {
+    throw new Error(json.error?.message ?? json.error?.code ?? `HTTP ${res.status}`)
+  }
+  // Unwrap the { success, data } envelope so callers always see plain data.
+  return json.data as T
+}
+
+// Build the query string for list calls. Pass `resolveDepth: 1` whenever
+// the entity has relations and the UI needs the related names, otherwise
+// the UI will render UUIDs.
+function listQuery(params: { page?: number; limit?: number; sort?: string; order?: 'asc' | 'desc'; search?: string; filters?: string; resolveDepth?: number } = {}) {
+  const qs = new URLSearchParams()
+  if (params.page) qs.set('page', String(params.page))
+  if (params.limit) qs.set('limit', String(params.limit))
+  if (params.sort) qs.set('sort', params.sort)
+  if (params.order) qs.set('order', params.order)
+  if (params.search) qs.set('search', params.search)
+  if (params.filters) qs.set('filters', params.filters)
+  if (params.resolveDepth) qs.set('resolve_depth', String(params.resolveDepth))
+  return qs.toString()
+}
+
+export interface ListResponse<R = Record<string, unknown>> {
+  items: R[]
+  total: number
+  page: number
+  limit: number
+  totalPages: number
 }
 
 export const api = {
   login: (email: string, password: string) =>
-    apiFetch('/api/auth/tenant/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
-  me: (token: string) => apiFetch('/api/auth/tenant/me', {}, token),
-  list: (entity: string, token: string, params = '') =>
-    apiFetch(`/api/entities/${entity}/records?${params}`, {}, token),
-  get: (entity: string, id: string, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, {}, token),
-  create: (entity: string, data: object, token: string) =>
-    apiFetch(`/api/entities/${entity}/records`, { method: 'POST', body: JSON.stringify(data) }, token),
-  update: (entity: string, id: string, data: object, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, { method: 'PUT', body: JSON.stringify(data) }, token),
+    apiFetch<{ token: string; user: User }>(
+      '/api/auth/tenant/login',
+      { method: 'POST', body: JSON.stringify({ email, password }) },
+    ),
+  me: (token: string) => apiFetch<User>('/api/auth/tenant/me', {}, token),
+
+  // Returns { items, total, page, limit, totalPages } — already unwrapped from
+  // the { success, data } envelope by apiFetch.
+  list: <R = Record<string, unknown>>(entity: string, token: string, params: Parameters<typeof listQuery>[0] = {}) =>
+    apiFetch<ListResponse<R>>(`/api/entities/${entity}/records?${listQuery(params)}`, {}, token),
+
+  get: <R = Record<string, unknown>>(entity: string, id: string, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records/${id}`, {}, token),
+
+  create: <R = Record<string, unknown>>(entity: string, data: object, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records`, { method: 'POST', body: JSON.stringify(data) }, token),
+
+  update: <R = Record<string, unknown>>(entity: string, id: string, data: object, token: string) =>
+    apiFetch<R>(`/api/entities/${entity}/records/${id}`, { method: 'PUT', body: JSON.stringify(data) }, token),
+
   remove: (entity: string, id: string, token: string) =>
-    apiFetch(`/api/entities/${entity}/records/${id}`, { method: 'DELETE' }, token),
+    apiFetch<{ id: string }>(`/api/entities/${entity}/records/${id}`, { method: 'DELETE' }, token),
 }
 ```
 
@@ -817,6 +870,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [token])
 
   const login = async (email: string, password: string) => {
+    // api.login returns the unwrapped { token, user } payload (envelope handled in api.ts).
     const { token: t, user: u } = await api.login(email, password)
     localStorage.setItem('fyso_token', t)
     setToken(t); setUser(u)
@@ -831,16 +885,21 @@ export const useAuth = () => useContext(AuthContext)!
 **Entity list with pagination:**
 ```tsx
 // EntityList.tsx
-export function EntityList({ entity }: { entity: string }) {
-  const { token, user } = useAuth()
-  const [records, setRecords] = useState([])
+//
+// Pass `hasRelations` for entities whose schema has at least one relation field
+// (query `get_entity_schema` during build to detect this). When true we request
+// `resolve_depth=1` so the table can show related names instead of UUIDs.
+export function EntityList({ entity, hasRelations }: { entity: string; hasRelations?: boolean }) {
+  const { token } = useAuth()
+  const [records, setRecords] = useState<Record<string, unknown>[]>([])
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
 
   useEffect(() => {
-    api.list(entity, token!, `page=${page}&limit=20`)
-      .then(r => { setRecords(r.data); setTotal(r.total) })
-  }, [entity, page, token])
+    // api.list returns the already-unwrapped { items, total, page, limit, totalPages } payload.
+    api.list(entity, token!, { page, limit: 20, resolveDepth: hasRelations ? 1 : undefined })
+      .then(r => { setRecords(r.items); setTotal(r.total) })
+  }, [entity, page, token, hasRelations])
 
   return (
     <div>
@@ -849,6 +908,15 @@ export function EntityList({ entity }: { entity: string }) {
     </div>
   )
 }
+```
+
+**Reading record fields:** records are flat. To show a related entity's name, request `resolveDepth: 1` and read `record.{relationKey}.{nameField}` (e.g. `record.cliente.nombre`). Without `resolve_depth` the relation field is a UUID string.
+
+**Client-side OR filtering:** the REST API supports AND-only compound filters. For OR conditions, fetch the AND subset on the server and filter `r.items` in the component:
+
+```tsx
+const r = await api.list('facturas', token!, { filters: 'estado = pendiente' })
+const visible = r.items.filter(f => f.estado === 'pendiente' || f.estado === 'vencida')
 ```
 
 **Create/edit form:**

--- a/skills/ui/templates/api-contracts.md
+++ b/skills/ui/templates/api-contracts.md
@@ -54,6 +54,8 @@ X-Tenant-ID: {tenant-slug}
 }
 ```
 
+> **Envelope rule (applies to ALL responses below):** every REST response is `{ success: boolean, data?: ..., error?: ... }`. Always unwrap `json.data` before use. See `reference/auth-patterns.md` → "REST API Response Patterns".
+
 ### Register (if self-registration enabled)
 
 ```http
@@ -116,22 +118,20 @@ X-Tenant-ID: {tenant-slug}
 |-------|-----|------|----------|--------|---------|-------|
 | {display} | {key} | {type} | {yes/no} | {yes/no} | {value} | {notes} |
 
-**Record shape:**
+**Record shape (flat, since v1.26.0):**
 ```json
 {
   "id": "uuid",
   "entityId": "uuid",
-  "name": "{value of name field}",
-  "data": {
-    "{field_key_1}": "{value}",
-    "{field_key_2}": "{value}"
-  },
+  "{field_key_1}": "{value}",
+  "{field_key_2}": "{value}",
+  "{relation_key}": "uuid-of-related-record",
   "createdAt": "ISO-8601",
   "updatedAt": "ISO-8601"
 }
 ```
 
-**IMPORTANT:** Entity field values are in `record.data.{fieldKey}`, NOT `record.{fieldKey}`.
+**IMPORTANT:** Record fields are flat — read them as `record.{fieldKey}`. There is no `record.data` nesting (the old nested format was removed in v1.26.0).
 
 **List:**
 ```http
@@ -140,14 +140,33 @@ X-API-Key: {token}
 X-Tenant-ID: {tenant-slug}
 ```
 
-Response: `{ data: { data: Record[], total, page, limit, totalPages } }`
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "items": [ { "id": "...", "...": "..." } ],
+    "total": 42,
+    "page": 1,
+    "limit": 20,
+    "totalPages": 3
+  }
+}
+```
+
+> Read the array from `json.data.items` — NOT `json.data` and NOT `json.data.data`.
 
 **Get One:**
 ```http
 GET /api/entities/{entity}/records/{id}
 ```
 
-Response: `{ data: Record }`
+Response:
+```json
+{ "success": true, "data": { "id": "...", "...": "..." } }
+```
+
+> Read the record from `json.data`. `resolve_depth` is NOT supported here — use the list endpoint with `?filters=id = {id}&resolve_depth=1` if you need expanded relations.
 
 **Create:**
 ```http
@@ -157,7 +176,7 @@ Content-Type: application/json
 { "{field_key_1}": "value1", "{field_key_2}": "value2" }
 ```
 
-Response 201: `{ data: Record }`
+Response 201: `{ "success": true, "data": Record }`
 
 **Update:**
 ```http
@@ -167,29 +186,33 @@ Content-Type: application/json
 { "{field_key}": "new_value" }
 ```
 
-Response: `{ data: Record }`
+Response: `{ "success": true, "data": Record }`
 
 **Delete:**
 ```http
 DELETE /api/entities/{entity}/records/{id}
 ```
 
-Response: `{ success: true }`
+Response: `{ "success": true }`
 
 **Search:**
 ```http
 GET /api/entities/{entity}/records?search={query}
 ```
 
-**Filters:**
+**Filters (server-side, AND only):**
 ```http
-GET /api/entities/{entity}/records?filter.{field}={value}
+GET /api/entities/{entity}/records?filters=estado = activo AND monto > 1000
 ```
 
-**Expand relations:**
+For OR conditions, fetch with the AND subset and filter `json.data.items` client-side.
+
+**Expand relations (list endpoint only):**
 ```http
-GET /api/entities/{entity}/records?resolve=true
+GET /api/entities/{entity}/records?resolve_depth=1
 ```
+
+When `resolve_depth=1`, every relation field on each item becomes a full nested object instead of a UUID string — use this whenever the UI needs to show a related entity's name (so you don't render UUIDs). For entities listed below with relations, ALWAYS request `resolve_depth=1` on list views.
 
 ---
 


### PR DESCRIPTION
## Summary

- Teach the generated UI to follow the REST envelope and `resolve_depth` rules (existing commit `c51c030`).
- Add a **Frontend Flow** subsection to every domain pattern in `skills/plan/reference/domain-patterns.md` documenting the typical user journey, the exact REST endpoints/params, and the common pitfalls (computed fields, `resolve_depth`, AND-only filters, non-transactional multi-entity transitions).
- Add a cross-cutting "Frontend / REST Conventions" block in Universal Patterns so the same rules don't have to be repeated per domain.

Sourced from real frontend build feedback (POS / mi-cafe — Item #4 in `FYSO-DOCS-FEEDBACK.md`).

## Test plan

- [ ] Render `skills/plan/reference/domain-patterns.md` and confirm each domain has a `### Frontend Flow` block with at least one Journey + Pitfalls.
- [ ] `bun bin/sync-reference.ts --check` passes (the domain-patterns extractor only summarises entities/relations/rules, so the consolidated reference is unaffected by the new prose — confirmed locally).
- [ ] Spot-check the Restaurant section: verify the order-edit and pay-and-close journeys match the actual REST calls a frontend would make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)