### PR TITLE
fix(setup-skill): MCP URL app.fyso.dev → mcp.fyso.dev

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -151,7 +151,7 @@ El plugin incluye `.mcp.json` que conecta via OAuth:
   "mcpServers": {
     "fyso": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://app.fyso.dev/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.fyso.dev/mcp"]
     }
   }
 }
@@ -173,7 +173,7 @@ Al usar cualquier herramienta por primera vez, se abre un flujo OAuth para auten
   "mcpServers": {
     "fyso": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://app.fyso.dev/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.fyso.dev/mcp"]
     }
   }
 }
@@ -207,6 +207,6 @@ Al usar cualquier herramienta por primera vez, se abre un flujo OAuth para auten
 
 | Error | Fix |
 |-------|-----|
-| MCP server not found | Verificar que `npx` este instalado: `npx --version`. Probar `curl https://app.fyso.dev/mcp/health` |
+| MCP server not found | Verificar que `npx` este instalado: `npx --version`. Probar `curl https://mcp.fyso.dev/mcp` (debe responder 401 con `WWW-Authenticate: Bearer`) |
 | Authentication failed | Reiniciar Claude Code para repetir flujo OAuth. Verificar cuenta activa en [fyso.dev](https://fyso.dev) |
 | Unknown action | Verificar que la accion sea valida para la herramienta — usar acciones exactas listadas arriba |


### PR DESCRIPTION
## Summary
- Setup skill still showed `https://app.fyso.dev/mcp` in three places (Claude Code config example, Claude Desktop config example, troubleshooting curl).
- `app.fyso.dev` is the SPA frontend and returns `text/html`, so users following these docs hit `SSE error: Invalid content type, expected "text/event-stream"`.
- `.mcp.json` was already corrected in 7bd952e but `skills/setup/SKILL.md` was missed; this completes that fix.

## Verification
- `curl -I https://mcp.fyso.dev/mcp` → `HTTP/2 401` with `WWW-Authenticate: Bearer resource_metadata="https://mcp.fyso.dev/.well-known/oauth-protected-resource"` (correct OAuth-protected MCP response).
- `curl -I https://app.fyso.dev/mcp` → `HTTP/2 200` with `content-type: text/html` (SPA catch-all — reproduces the bug).
- No remaining `app.fyso.dev/mcp` references under tracked files.

## Test plan
- [ ] `/plugin install fyso@fyso-plugins` + `/reload-plugins` connects without SSE error
- [ ] Manual Claude Desktop setup using docs in `skills/setup/SKILL.md` works against `mcp.fyso.dev`
- [ ] Troubleshooting curl in the table returns 401 (auth-gated) instead of HTML

Refs: PLG-10. Replaces the unmerged work from PR #1 (closed/rejected) — only the three doc lines remain to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)