### PR TITLE
docs: fix resolve_depth single-record claim + add Restaurant pagos entity

### DIFF
--- a/FYSO-REFERENCE.md
+++ b/FYSO-REFERENCE.md
@@ -183,7 +183,7 @@ DELETE /api/entities/{entity}/records/:id      # Delete
 ?order=desc            # asc or desc
 ?filters=field = value              # single filter
 ?filters=field = value AND other = x  # compound (AND only, no OR)
-?resolve_depth=1       # inline related objects (max 2, list endpoints only)
+?resolve_depth=1       # inline related objects (max 2 on list, max 3 on single record)
 ```
 
 ### Filter Operators
@@ -237,8 +237,9 @@ ws://app.fyso.dev/ws?token={api_key}&tenantId={slug}
 Per-entity toggle: `realtimeEnabled` in entity metadata.
 
 ### resolve_depth behavior
-- Only works on list endpoints (GET /records), NOT on single record (GET /records/:id)
-- Max depth: 2
+- List endpoints (GET /records): max depth 2
+- Single record (GET /records/:id): max depth 3
+- MCP `fyso_data({ action: "query" })`: max depth 3
 - Transforms relation fields from UUID strings to full objects
 
 Source: `skills/api/reference/rest-api.md`
@@ -306,10 +307,9 @@ Source: `skills/rules/reference/dsl-reference.md`
 | 9 | `deploy` response `url` field is wrong — returns `{slug}.fyso.dev` without `-sites` | High | Always use `{slug}-sites.fyso.dev` as the real URL |
 | 10 | Fyso static hosting ignores `_redirects` — BrowserRouter SPA routes 404 on direct access | High | Use Astro (generates per-route index.html) or HashRouter for SPAs |
 | 11 | OR filters not supported server-side | Medium | Client-side filter for OR conditions |
-| 12 | resolve_depth only on list endpoints | Low | Separate GET /records/:id call per related entity |
-| 13 | No aggregation queries (SUM, COUNT, AVG) | Medium | Fetch all records + compute client-side |
-| 14 | Agent REST endpoint returns 401 with user tokens | High | Use MCP `fyso_agents({ action: "run" })` instead |
-| 15 | `contains` filter: case sensitivity / Unicode collation not specified, no wildcards | Medium | Test against your data; for guaranteed text search use semantic search or a normalized field |
+| 12 | No aggregation queries (SUM, COUNT, AVG) | Medium | Fetch all records + compute client-side |
+| 13 | Agent REST endpoint returns 401 with user tokens | High | Use MCP `fyso_agents({ action: "run" })` instead |
+| 14 | `contains` filter: case sensitivity / Unicode collation not specified, no wildcards | Medium | Test against your data; for guaranteed text search use semantic search or a normalized field |
 
 **Things that work fine:** Multiple entity creation, rules after publish, relations, `fyso_data({ action: "query" })`, metadata import/export.
 
@@ -335,9 +335,9 @@ Source: `skills/plan/reference/limitations.md`
 - **Rules:** Compute: factura total = subtotal + iva, Compute: proyecto horas_total = sum of tareas horas_reales (requires after_save action), Validate: fecha_fin >= fecha_inicio, Validate: horas_estimadas > 0
 
 ### Restaurant
-- **Entities:** platos, mesas, pedidos, detalle_pedido
-- **Key relations:** pedidos→mesas, detalle_pedido→pedidos, detalle_pedido→platos
-- **Rules:** Compute: detalle subtotal = cantidad * precio_unitario, Validate: cantidad > 0, Validate: plato disponible == true
+- **Entities:** platos, mesas, pedidos, detalle_pedido, pagos
+- **Key relations:** pedidos→mesas, detalle_pedido→pedidos, detalle_pedido→platos, pagos→pedidos
+- **Rules:** Compute: detalle subtotal = cantidad * precio_unitario, Validate: cantidad > 0, Validate: plato disponible == true, Validate: monto pago > 0
 
 ### Repair Shop / Workshop
 - **Entities:** clientes, trabajos, repuestos, detalle_trabajo

--- a/bin/sync-reference.ts
+++ b/bin/sync-reference.ts
@@ -259,7 +259,7 @@ DELETE /api/entities/{entity}/records/:id      # Delete
 ?order=desc            # asc or desc
 ?filters=field = value              # single filter
 ?filters=field = value AND other = x  # compound (AND only, no OR)
-?resolve_depth=1       # inline related objects (max 2, list endpoints only)
+?resolve_depth=1       # inline related objects (max 2 on list, max 3 on single record)
 \`\`\`
 
 ### Filter Operators
@@ -313,8 +313,9 @@ ws://app.fyso.dev/ws?token={api_key}&tenantId={slug}
 Per-entity toggle: \`realtimeEnabled\` in entity metadata.
 
 ### resolve_depth behavior
-- Only works on list endpoints (GET /records), NOT on single record (GET /records/:id)
-- Max depth: 2
+- List endpoints (GET /records): max depth 2
+- Single record (GET /records/:id): max depth 3
+- MCP \`fyso_data({ action: "query" })\`: max depth 3
 - Transforms relation fields from UUID strings to full objects`;
 }
 
@@ -374,10 +375,9 @@ function extractLimitations(content: string): string {
 | 9 | \`deploy\` response \`url\` field is wrong — returns \`{slug}.fyso.dev\` without \`-sites\` | High | Always use \`{slug}-sites.fyso.dev\` as the real URL |
 | 10 | Fyso static hosting ignores \`_redirects\` — BrowserRouter SPA routes 404 on direct access | High | Use Astro (generates per-route index.html) or HashRouter for SPAs |
 | 11 | OR filters not supported server-side | Medium | Client-side filter for OR conditions |
-| 12 | resolve_depth only on list endpoints | Low | Separate GET /records/:id call per related entity |
-| 13 | No aggregation queries (SUM, COUNT, AVG) | Medium | Fetch all records + compute client-side |
-| 14 | Agent REST endpoint returns 401 with user tokens | High | Use MCP \`fyso_agents({ action: "run" })\` instead |
-| 15 | \`contains\` filter: case sensitivity / Unicode collation not specified, no wildcards | Medium | Test against your data; for guaranteed text search use semantic search or a normalized field |
+| 12 | No aggregation queries (SUM, COUNT, AVG) | Medium | Fetch all records + compute client-side |
+| 13 | Agent REST endpoint returns 401 with user tokens | High | Use MCP \`fyso_agents({ action: "run" })\` instead |
+| 14 | \`contains\` filter: case sensitivity / Unicode collation not specified, no wildcards | Medium | Test against your data; for guaranteed text search use semantic search or a normalized field |
 
 **Things that work fine:** Multiple entity creation, rules after publish, relations, \`fyso_data({ action: "query" })\`, metadata import/export.`;
 }

--- a/skills/plan/reference/domain-patterns.md
+++ b/skills/plan/reference/domain-patterns.md
@@ -110,11 +110,13 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 - **mesas** — numero(number, unique), capacidad(number), estado(select: libre/ocupada/reservada)
 - **pedidos** — mesa(rel→mesas), fecha(date), hora(text), total(number), estado(select: abierto/en_preparacion/servido/cerrado), mesero(text)
 - **detalle_pedido** — pedido(rel→pedidos), plato(rel→platos), cantidad(number), precio_unitario(number), subtotal(number), notas(text)
+- **pagos** — pedido(rel→pedidos), fecha(date), monto(number), metodo(select: efectivo/tarjeta/transferencia)
 
 ### Common Rules
 - Compute: detalle subtotal = cantidad * precio_unitario
 - Validate: cantidad > 0
 - Validate: plato disponible == true
+- Validate: monto pago > 0
 
 ### Frontend Flow
 
@@ -133,7 +135,7 @@ Use this reference when designing Fyso apps. These patterns cover the most commo
 
 **Journey: Pay and close**
 1. Refetch pedido for the outstanding total.
-2. Create pago → `POST /api/entities/pagos/records` with `{ pedido, monto, metodo, fecha }` (assumes a `pagos` entity in your tenant — reuse the pattern from Freelancer if you need to model it).
+2. Create pago → `POST /api/entities/pagos/records` with `{ pedido, monto, metodo, fecha }`
 3. Close pedido → `PUT /api/entities/pedidos/records/:id` with `{ estado: "cerrado" }`
 4. Free the mesa → `PUT /api/entities/mesas/records/:mesa_id` with `{ estado: "libre" }`
 

--- a/skills/plan/reference/limitations.md
+++ b/skills/plan/reference/limitations.md
@@ -146,16 +146,7 @@ The REST API and fyso_data `query` action only support AND compound filters. The
 
 **Workaround:** Fetch records with the broadest applicable filter and apply OR conditions client-side after receiving results.
 
-### 12. resolve_depth only works on list endpoints
-
-**Impact:** Low
-**Affects:** Single record fetches with related entity resolution
-
-`resolve_depth` only works on `GET /records` (list) and `fyso_data({ action: "query" })`. It does NOT work on `GET /records/:id` (single record fetch).
-
-**Workaround:** After fetching a single record, make separate `GET /records/:id` calls for each related entity UUID you need to resolve.
-
-### 13. No aggregation queries (SUM, COUNT, AVG)
+### 12. No aggregation queries (SUM, COUNT, AVG)
 
 **Impact:** Medium
 **Affects:** Dashboard KPIs, totals, statistical summaries
@@ -164,7 +155,7 @@ Fyso has no server-side aggregation. There are no SUM, COUNT, AVG, GROUP BY quer
 
 **Workaround:** Fetch all relevant records (using pagination if needed) and compute aggregations client-side.
 
-### 14. Agent REST endpoint returns 401 with user tokens
+### 13. Agent REST endpoint returns 401 with user tokens
 
 **Impact:** High
 **Affects:** Calling `/api/agents/{slug}/run` from client-side code

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -571,7 +571,7 @@ GET /api/entities/{entity}/records/{id}
 Response data: { id, entityId, ...fields, createdAt, updatedAt }
 ```
 
-Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`. `resolve_depth` is not supported on this endpoint — use the list endpoint with an id filter if you need expanded relations.
+Records are flat (since v1.26.0): read fields as `record.fieldKey`, never `record.data.fieldKey`. Pass `?resolve_depth=1` (max 3) when you need related fields expanded as nested objects instead of UUID strings.
 
 **Create:**
 ```

--- a/skills/ui/reference/auth-patterns.md
+++ b/skills/ui/reference/auth-patterns.md
@@ -283,7 +283,7 @@ record.data.nombre  // undefined — data is NOT nested
 
 ### resolve_depth — Inline Related Objects
 
-Use `?resolve_depth=1` on list endpoints to replace relation UUID fields with full objects. Only works on list (GET /records), NOT on single record (GET /records/:id).
+Use `?resolve_depth=1` to replace relation UUID fields with full objects. Supported on list endpoints (max depth 2) and on single-record GET (max depth 3).
 
 ```ts
 // Without resolve_depth:

--- a/skills/ui/templates/api-contracts.md
+++ b/skills/ui/templates/api-contracts.md
@@ -166,7 +166,7 @@ Response:
 { "success": true, "data": { "id": "...", "...": "..." } }
 ```
 
-> Read the record from `json.data`. `resolve_depth` is NOT supported here — use the list endpoint with `?filters=id = {id}&resolve_depth=1` if you need expanded relations.
+> Read the record from `json.data`. Pass `?resolve_depth=1` (max 3) when you need related fields expanded as nested objects instead of UUID strings.
 
 **Create:**
 ```http
@@ -207,12 +207,13 @@ GET /api/entities/{entity}/records?filters=estado = activo AND monto > 1000
 
 For OR conditions, fetch with the AND subset and filter `json.data.items` client-side.
 
-**Expand relations (list endpoint only):**
+**Expand relations:**
 ```http
 GET /api/entities/{entity}/records?resolve_depth=1
+GET /api/entities/{entity}/records/{id}?resolve_depth=1
 ```
 
-When `resolve_depth=1`, every relation field on each item becomes a full nested object instead of a UUID string — use this whenever the UI needs to show a related entity's name (so you don't render UUIDs). For entities listed below with relations, ALWAYS request `resolve_depth=1` on list views.
+When `resolve_depth=1`, every relation field on the response becomes a full nested object instead of a UUID string — use this whenever the UI needs to show a related entity's name (so you don't render UUIDs). Supported on list (max depth 2) and on single-record GET (max depth 3). For entities listed below with relations, ALWAYS request `resolve_depth=1`.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to PR #33 post-merge review (sebastianbarrozo / crisol):

- **Fix `resolve_depth` contradiction.** The canonical reference (`skills/api/reference/rest-api.md`) says single-record GET supports `resolve_depth` (max depth 3), but several files carried the opposite claim. Now aligned across `skills/ui/SKILL.md`, `skills/ui/templates/api-contracts.md`, `skills/ui/reference/auth-patterns.md`, `skills/plan/reference/limitations.md` (removed item #12 entirely), `bin/sync-reference.ts`, and the regenerated `FYSO-REFERENCE.md`.
- **Promote `pagos` to a Restaurant entity.** The Pay-and-close flow added in #33 used `pagos` with a "assumes a pagos entity in your tenant" note; the mi-cafe POS feedback specifically asked for the payment step, so `pagos` is now part of the pattern and the conditional note is gone.

## Test plan

- [ ] `grep -rni "resolve_depth.*not supported\|list endpoints.*NOT on single\|only works on list"` returns nothing in skills/, bin/, FYSO-REFERENCE.md.
- [ ] Restaurant section in `skills/plan/reference/domain-patterns.md` lists `pagos` and the Pay-and-close journey no longer carries the "assumes a pagos entity" caveat.
- [ ] `bun bin/sync-reference.ts --check` passes (regenerated FYSO-REFERENCE.md was committed alongside the script change so the check should be clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)