### PR TITLE
fix(channel-server): sanitize HTTP error bodies in logs

### DIFF
--- a/bin/channel-server.ts
+++ b/bin/channel-server.ts
@@ -22,6 +22,23 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a safe, human-readable error message from an HTTP response body.
+ * Avoids leaking stack traces, internal field names, or DB details into logs.
+ */
+function safeErrorMessage(body: string, status: number): string {
+  try {
+    const parsed = JSON.parse(body);
+    const msg = parsed?.error?.message ?? parsed?.error ?? parsed?.message;
+    if (typeof msg === 'string' && msg.length > 0) return msg;
+  } catch {}
+  return `HTTP ${status}`;
+}
+
+// ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
@@ -81,7 +98,7 @@ if (!AGENT_ID && AGENT_NAME && TENANT_SLUG && API_KEY) {
       }
     } else {
       const body = await regRes.text().catch(() => '');
-      console.error(`[fyso-channel] Registration failed (${regRes.status}): ${body}`);
+      console.error(`[fyso-channel] Registration failed: ${safeErrorMessage(body, regRes.status)}`);
     }
   } catch (err: any) {
     console.error(`[fyso-channel] Registration error: ${err?.message}`);
@@ -334,7 +351,7 @@ async function startSseBridge(): Promise<() => void> {
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      console.error(`[fyso-channel] SSE HTTP ${response.status}: ${body}`);
+      console.error(`[fyso-channel] SSE HTTP ${response.status}: ${safeErrorMessage(body, response.status)}`);
       if (response.status === 401 || response.status === 403) {
         await mcp.notification({
           method: 'notifications/claude/channel',


### PR DESCRIPTION
## Summary
- `bin/channel-server.ts` was logging the full HTTP response body on registration and SSE connection failures, which could leak stack traces, internal field names, or DB details if the backend ever included them in error responses.
- Added a `safeErrorMessage(body, status)` helper that extracts only `error.message` / `error` / `message` from a JSON body, falling back to `HTTP <status>`.
- Applied to both error sites (registration failure, SSE non-OK response). Reconnection / functional behavior is unchanged.

## Test plan
- [ ] Trigger a registration failure (e.g., bad `FYSO_API_KEY`) and confirm logs show only the sanitized message, no raw body.
- [ ] Trigger an SSE 4xx (e.g., wrong `FYSO_TENANT_SLUG`) and confirm the same.
- [ ] Confirm reconnect/backoff still operates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)