### PR TITLE
fix(tracking): drop redundant Z that produced ZZ timestamp

### DIFF
--- a/opencode-plugin/src/tracking.ts
+++ b/opencode-plugin/src/tracking.ts
@@ -74,7 +74,7 @@ export function createTracker() {
 
       const payload: Record<string, unknown> = {
         ...event,
-        timestamp: new Date().toISOString() + "Z",
+        timestamp: new Date().toISOString(),
       }
       // Remove null/undefined
       for (const key of Object.keys(payload)) {


### PR DESCRIPTION
## Summary
- `Date.toISOString()` already returns a Z-suffixed string, so `+ "Z"` produced malformed `...ZZ` timestamps in every OpenCode plugin tracking event (`session_start`, `agent_dispatch`, `session_update`, `heartbeat`).
- The bash hooks (`hooks/tracking.sh`, `hooks/heartbeat.sh`) remain unchanged — Python's `datetime.isoformat()` does not append `Z`, so the `+ "Z"` there is correct.
- Verified no other `.toISOString() + "Z"` patterns exist in the TypeScript source.

## Test plan
- [x] `npx vitest run` in `opencode-plugin/` — all 14 tests pass
- [x] `grep` confirmed line 77 was the only redundant `+ "Z"` occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)