### PR TITLE
refactor(tracking): unify PRICING table and inferModelFamily default

### DIFF
--- a/hooks/heartbeat.sh
+++ b/hooks/heartbeat.sh
@@ -6,6 +6,10 @@
 CONFIG="$HOME/.fyso/config.json"
 [ ! -f "$CONFIG" ] && exit 0
 
+# Resolve shared pricing source of truth (sibling opencode-plugin/src/pricing.json)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PRICING_FILE="$SCRIPT_DIR/../opencode-plugin/src/pricing.json"
+
 # Read session info from stdin (SessionStart JSON)
 STDIN_DATA=$(cat 2>/dev/null || true)
 
@@ -126,13 +130,17 @@ for line in lines:
         continue
 total_tokens = total_input + total_output + total_cache_creation + total_cache_read
 
-# Cost calculation (per 1M tokens)
-PRICING = {
-    "opus":   {"input": 15,   "output": 75,  "cache_write": 3.75, "cache_read": 0.375},
-    "sonnet": {"input": 3,    "output": 15,  "cache_write": 3.75,  "cache_read": 0.3},
-    "haiku":  {"input": 0.8,  "output": 4,   "cache_write": 1.0,   "cache_read": 0.08},
-}
-model_family = "opus" if "opus" in model else "sonnet" if "sonnet" in model else "haiku" if "haiku" in model else ""
+# Cost calculation (per 1M tokens) — loaded from shared source of truth
+PRICING = {}
+DEFAULT_FAMILY = "opus"
+try:
+    with open(os.environ.get("PRICING_FILE", "")) as pf:
+        _pdata = json.load(pf)
+    PRICING = _pdata.get("pricing", {})
+    DEFAULT_FAMILY = _pdata.get("default_family", "opus")
+except:
+    pass
+model_family = "opus" if "opus" in model else "sonnet" if "sonnet" in model else "haiku" if "haiku" in model else DEFAULT_FAMILY
 p = PRICING.get(model_family, {})
 cost_usd = (total_input / 1e6) * p.get("input", 0) + (total_output / 1e6) * p.get("output", 0) + (total_cache_creation / 1e6) * p.get("cache_write", 0) + (total_cache_read / 1e6) * p.get("cache_read", 0) if p else 0
 

--- a/hooks/tracking.sh
+++ b/hooks/tracking.sh
@@ -6,6 +6,10 @@
 CONFIG="$HOME/.fyso/config.json"
 [ ! -f "$CONFIG" ] && exit 0
 
+# Resolve shared pricing source of truth (sibling opencode-plugin/src/pricing.json)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRICING_FILE="$SCRIPT_DIR/../opencode-plugin/src/pricing.json"
+
 # Read stdin to temp file (avoids quoting issues)
 TMPFILE=$(mktemp)
 cat > "$TMPFILE" 2>/dev/null || true
@@ -21,7 +25,7 @@ if [ -f "$HOME/.fyso/debug" ]; then
 fi
 
 # Single python call: read config + parse stdin + build payload + send
-export TMPFILE EVENT_TYPE
+export TMPFILE EVENT_TYPE PRICING_FILE
 python3 << 'PYEOF'
 import json, re, datetime, os, sys, getpass, hashlib
 try:
@@ -43,6 +47,15 @@ user_email = cfg.get("user_email", "")
 
 if not token or not tenant:
     sys.exit(0)
+
+# Load shared pricing source of truth (PRICING table + default_family)
+DEFAULT_FAMILY = "opus"
+try:
+    with open(os.environ.get("PRICING_FILE", "")) as pf:
+        _pdata = json.load(pf)
+    DEFAULT_FAMILY = _pdata.get("default_family", "opus")
+except:
+    pass
 
 # Read stdin JSON from temp file (once)
 tmpfile = os.environ.get("TMPFILE", "")
@@ -225,7 +238,7 @@ if event_type in ("session_end", "session_update"):
     cache_read_tokens = 0
 
 # Model family (for business rule cost calculation server-side)
-model_family = "opus" if "opus" in model else "sonnet" if "sonnet" in model else "haiku" if "haiku" in model else "opus"
+model_family = "opus" if "opus" in model else "sonnet" if "sonnet" in model else "haiku" if "haiku" in model else DEFAULT_FAMILY
 
 # User
 user = user_email or getpass.getuser()

--- a/opencode-plugin/src/pricing.json
+++ b/opencode-plugin/src/pricing.json
@@ -1,0 +1,8 @@
+{
+  "default_family": "opus",
+  "pricing": {
+    "opus":   { "input": 15,  "output": 75, "cache_write": 3.75, "cache_read": 0.375 },
+    "sonnet": { "input": 3,   "output": 15, "cache_write": 3.75, "cache_read": 0.3 },
+    "haiku":  { "input": 0.8, "output": 4,  "cache_write": 1.0,  "cache_read": 0.08 }
+  }
+}

--- a/opencode-plugin/src/tracking.ts
+++ b/opencode-plugin/src/tracking.ts
@@ -1,6 +1,18 @@
 import { readConfig, readTeamConfig, apiRequest, debugLog } from "./config"
 import { createHash } from "crypto"
 import { userInfo } from "os"
+import { readFileSync } from "fs"
+import { fileURLToPath } from "url"
+import { dirname, join } from "path"
+
+const pricingData = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "pricing.json"), "utf8"),
+) as {
+  default_family: string
+  pricing: Record<string, Record<string, number>>
+}
+
+const DEFAULT_FAMILY = pricingData.default_family
 
 interface TrackingEvent {
   event: string
@@ -32,14 +44,10 @@ export function inferModelFamily(model: string): string {
   if (model.includes("opus")) return "opus"
   if (model.includes("sonnet")) return "sonnet"
   if (model.includes("haiku")) return "haiku"
-  return "opus"
+  return DEFAULT_FAMILY
 }
 
-export const PRICING: Record<string, Record<string, number>> = {
-  opus: { input: 15, output: 75, cache_write: 3.75, cache_read: 0.375 },
-  sonnet: { input: 3, output: 15, cache_write: 3.75, cache_read: 0.3 },
-  haiku: { input: 0.8, output: 4, cache_write: 1.0, cache_read: 0.08 },
-}
+export const PRICING = pricingData.pricing
 
 export function calculateCost(
   family: string,


### PR DESCRIPTION
## Summary
- Move the per-model pricing table and the unrecognized-model default into a single JSON source of truth at `opencode-plugin/src/pricing.json`.
- `opencode-plugin/src/tracking.ts` loads it via `import.meta.url`; both `hooks/tracking.sh` and `hooks/heartbeat.sh` resolve the path from their script location and pass it to the embedded Python via the `PRICING_FILE` env var.
- Fixes the divergent default in `heartbeat.sh` that returned `""` for unrecognized models (causing `cost_usd = 0`), now consistent with the `"opus"` default used by the other two paths.

## Test plan
- [x] `npm test` (vitest) in `opencode-plugin/` — 14 tests pass, including `inferModelFamily` and `calculateCost` coverage.
- [x] `bash -n` syntax check on both updated hook scripts.
- [x] Smoke-test JSON load in Python with the same shape used by the embedded snippets; unknown model now resolves to `opus` pricing.
- [ ] Manual run: trigger a heartbeat with a non-claude model name and verify `cost_usd` matches what `tracking.ts` produces for the same input.
- [ ] Edit a price in `pricing.json` and verify all three flows (OpenCode tracker, Claude Code tracking hook, heartbeat) reflect the change without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)