### PR TITLE
refactor(tracking): consolidate token sum helper + heartbeat parity

### DIFF
--- a/hooks/heartbeat.sh
+++ b/hooks/heartbeat.sh
@@ -140,6 +140,11 @@ try:
     DEFAULT_FAMILY = _pdata.get("default_family", "opus")
 except:
     pass
+
+# Fallback: default to opus when transcript yields no model (parity with tracking.sh / tracking.ts)
+if not model:
+    model = "claude-opus-4-6"
+
 model_family = "opus" if "opus" in model else "sonnet" if "sonnet" in model else "haiku" if "haiku" in model else DEFAULT_FAMILY
 p = PRICING.get(model_family, {})
 cost_usd = (total_input / 1e6) * p.get("input", 0) + (total_output / 1e6) * p.get("output", 0) + (total_cache_creation / 1e6) * p.get("cache_write", 0) + (total_cache_read / 1e6) * p.get("cache_read", 0) if p else 0
@@ -163,11 +168,22 @@ data = {
     "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
 }
 data = {k: v for k, v in data.items() if v is not None}
+payload = json.dumps(data).encode()
+
+debug_path = os.path.expanduser("~/.fyso/debug")
+log_path = os.path.expanduser("~/.fyso/hook-debug.log")
+is_debug = os.path.exists(debug_path)
+
+if is_debug:
+    with open(log_path, "a") as dl:
+        dl.write(f"=== {datetime.datetime.utcnow().isoformat()}Z === EVENT=heartbeat ===\n")
+        dl.write(f"TRANSCRIPT: path={transcript} lines={len(lines)} model={model} session_tokens={total_tokens}\n")
+        dl.write(f"PAYLOAD: {payload.decode()}\n")
 
 try:
     req = urllib.request.Request(
         f"{api_url}/api/entities/tracking/records",
-        data=json.dumps(data).encode(),
+        data=payload,
         headers={
             "Authorization": f"Bearer {token}",
             "X-Tenant-ID": tenant,
@@ -175,9 +191,15 @@ try:
         },
         method="POST",
     )
-    urllib.request.urlopen(req, timeout=5)
-except:
-    pass
+    resp = urllib.request.urlopen(req, timeout=5)
+    if is_debug:
+        resp_body = resp.read().decode()
+        with open(log_path, "a") as dl:
+            dl.write(f"RESPONSE: {resp.status} {resp_body[:200]}\n\n")
+except Exception as e:
+    if is_debug:
+        with open(log_path, "a") as dl:
+            dl.write(f"ERROR: {e}\n\n")
 PYEOF
 
 done

--- a/opencode-plugin/src/tracking.ts
+++ b/opencode-plugin/src/tracking.ts
@@ -49,6 +49,17 @@ export function inferModelFamily(model: string): string {
 
 export const PRICING = pricingData.pricing
 
+export interface SessionTokens {
+  input: number
+  output: number
+  cache_creation: number
+  cache_read: number
+}
+
+export function totalSessionTokens(t: SessionTokens): number {
+  return t.input + t.output + t.cache_creation + t.cache_read
+}
+
 export function calculateCost(
   family: string,
   input: number,
@@ -67,7 +78,7 @@ export function calculateCost(
 }
 
 export function createTracker() {
-  let sessionTokens = {
+  let sessionTokens: SessionTokens = {
     input: 0,
     output: 0,
     cache_creation: 0,
@@ -164,11 +175,7 @@ export function createTracker() {
         output_tokens: outputTokens,
         cache_creation_tokens: cacheCreation,
         cache_read_tokens: cacheRead,
-        session_tokens:
-          sessionTokens.input +
-          sessionTokens.output +
-          sessionTokens.cache_creation +
-          sessionTokens.cache_read,
+        session_tokens: totalSessionTokens(sessionTokens),
         session_input_tokens: sessionTokens.input,
         session_output_tokens: sessionTokens.output,
         session_cache_creation_tokens: sessionTokens.cache_creation,
@@ -183,11 +190,7 @@ export function createTracker() {
       const team = await readTeamConfig(ctx.directory || process.cwd())
       const model = lastModel || "claude-opus-4-6"
       const family = inferModelFamily(model)
-      const totalTokens =
-        sessionTokens.input +
-        sessionTokens.output +
-        sessionTokens.cache_creation +
-        sessionTokens.cache_read
+      const totalTokens = totalSessionTokens(sessionTokens)
 
       await send({
         event: "session_update",
@@ -224,11 +227,7 @@ export function createTracker() {
       const team = await readTeamConfig(ctx.directory || process.cwd())
       const model = lastModel || "claude-opus-4-6"
       const family = inferModelFamily(model)
-      const totalTokens =
-        sessionTokens.input +
-        sessionTokens.output +
-        sessionTokens.cache_creation +
-        sessionTokens.cache_read
+      const totalTokens = totalSessionTokens(sessionTokens)
 
       await send({
         event: "heartbeat",


### PR DESCRIPTION
## Summary
- Extract `totalSessionTokens()` helper in `opencode-plugin/src/tracking.ts`; replace the 3 inlined `input + output + cache_creation + cache_read` sums in `toolExecuted`, `sessionEnd`, and `heartbeat`.
- `hooks/heartbeat.sh`: add `"claude-opus-4-6"` model fallback when the transcript yields no model — matches `tracking.sh:210` and `tracking.ts` so heartbeat events no longer ship a null model.
- `hooks/heartbeat.sh`: add `~/.fyso/debug` logging (event header, transcript stats, payload, response/error) consistent with `tracking.sh:16-21` so failures in the 5-minute heartbeat loop are no longer opaque.

The single-source-of-truth `pricing.json` (consumed by all three paths) and the shared `DEFAULT_FAMILY` were already in place from f50a300; this PR closes the remaining acceptance criteria from the issue.

## Test plan
- [x] `npx vitest run` in `opencode-plugin/` — 14 tests pass (cost calc, model inference, token accumulation).
- [x] `bash -n hooks/heartbeat.sh && bash -n hooks/tracking.sh` — clean.
- [x] Embedded Python in `heartbeat.sh` parses with `ast.parse`.
- [ ] Manual: enable `~/.fyso/debug`, trigger a session with at least one tool call, confirm `hook-debug.log` now contains heartbeat entries with consistent `model`, `model_family`, `cost_usd`.