### PR TITLE
fix(config): validate resp.ok in apiRequest, throw typed ApiRequestError

### DIFF
--- a/opencode-plugin/src/config.test.ts
+++ b/opencode-plugin/src/config.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { apiRequest, ApiRequestError, type FysoConfig } from "./config"
+
+const config: FysoConfig = {
+  token: "t",
+  tenant_id: "tenant",
+  api_url: "https://api.test",
+}
+
+describe("apiRequest response validation", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("throws ApiRequestError with the status code on non-ok responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await expect(apiRequest(config, "GET", "/api/entities/teams/records")).rejects.toMatchObject({
+      name: "ApiRequestError",
+      status: 401,
+    })
+  })
+
+  it("includes a body snippet truncated to 500 chars", async () => {
+    const longBody = "x".repeat(800)
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(longBody, { status: 500 }),
+    )
+
+    let caught: unknown
+    try {
+      await apiRequest(config, "POST", "/api/entities/tracking/records", { foo: 1 })
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(ApiRequestError)
+    const err = caught as ApiRequestError
+    expect(err.status).toBe(500)
+    expect(err.bodySnippet.length).toBeLessThanOrEqual(501)
+    expect(err.bodySnippet.endsWith("…")).toBe(true)
+    expect(err.message).toContain("HTTP 500")
+  })
+
+  it("returns parsed JSON on 2xx responses", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { items: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    const result = await apiRequest(config, "GET", "/api/entities/teams/records")
+    expect(result).toEqual({ data: { items: [] } })
+  })
+})

--- a/opencode-plugin/src/config.ts
+++ b/opencode-plugin/src/config.ts
@@ -58,6 +58,22 @@ export async function debugLog(message: string): Promise<void> {
   }
 }
 
+export class ApiRequestError extends Error {
+  readonly status: number
+  readonly method: string
+  readonly path: string
+  readonly bodySnippet: string
+
+  constructor(method: string, path: string, status: number, bodySnippet: string) {
+    super(`apiRequest ${method} ${path} failed with HTTP ${status}: ${bodySnippet}`)
+    this.name = "ApiRequestError"
+    this.method = method
+    this.path = path
+    this.status = status
+    this.bodySnippet = bodySnippet
+  }
+}
+
 export async function apiRequest(
   config: FysoConfig,
   method: string,
@@ -77,6 +93,13 @@ export async function apiRequest(
     body: body ? JSON.stringify(body) : undefined,
     signal: AbortSignal.timeout(5000),
   })
+
+  if (!resp.ok) {
+    const raw = await resp.text().catch(() => "")
+    const snippet = raw.length > 500 ? raw.slice(0, 500) + "…" : raw
+    await debugLog(`API_HTTP_ERROR: ${method} ${path} -> ${resp.status} ${snippet}`)
+    throw new ApiRequestError(method, path, resp.status, snippet)
+  }
 
   return resp.json()
 }

--- a/opencode-plugin/src/tracking.test.ts
+++ b/opencode-plugin/src/tracking.test.ts
@@ -8,7 +8,7 @@ vi.mock("./config", () => ({
 }))
 
 import { calculateCost, inferModelFamily, PRICING, createTracker } from "./tracking"
-import { readConfig, readTeamConfig, apiRequest } from "./config"
+import { readConfig, readTeamConfig, apiRequest, debugLog } from "./config"
 
 describe("inferModelFamily", () => {
   it("returns opus for opus model strings", () => {
@@ -167,5 +167,19 @@ describe("createTracker token accumulation", () => {
     const bPayload = calls[1][3] as Record<string, number>
     expect(aPayload.session_input_tokens).toBe(100)
     expect(bPayload.session_input_tokens).toBe(7)
+  })
+
+  it("logs the error via debugLog when apiRequest rejects on HTTP 500", async () => {
+    vi.mocked(apiRequest).mockRejectedValueOnce(
+      new Error("apiRequest POST /api/entities/tracking/records failed with HTTP 500: boom"),
+    )
+
+    const tracker = createTracker()
+    await expect(tracker.toolExecuted({ input_tokens: 10 })).resolves.toBeUndefined()
+
+    const debugCalls = vi.mocked(debugLog).mock.calls.map((c) => c[0])
+    const errorLog = debugCalls.find((m) => m.startsWith("TRACKING_ERROR:"))
+    expect(errorLog).toBeDefined()
+    expect(errorLog).toContain("HTTP 500")
   })
 })


### PR DESCRIPTION
## Summary
- `apiRequest()` ahora valida `resp.ok` y lanza `ApiRequestError` (con `status`, `method`, `path` y un fragmento del cuerpo truncado a 500 chars) cuando la API devuelve un error HTTP.
- `debugLog` registra todas las respuestas no-ok (`API_HTTP_ERROR: …`) para diagnóstico, eliminando los fallos silenciosos en tracking y `sync-team`.
- Los consumidores (`tracking.ts`) ya capturaban excepciones y ahora reportan el error al log; los que necesiten manejo específico (e.g. 401) pueden capturar `ApiRequestError`.

## Tests
- Nuevo `src/config.test.ts`: mockea `fetch` y verifica que un 401 lanza `ApiRequestError` con el status, que un body largo se trunca con `…`, y que respuestas 2xx siguen retornando JSON.
- `src/tracking.test.ts`: añade un caso donde `apiRequest` rechaza con un error simulando HTTP 500 y verifica que `tracker.toolExecuted` no propaga la excepción y que `debugLog` recibe `TRACKING_ERROR: … HTTP 500`.

## Test plan
- [x] `npm test` en `opencode-plugin/` (18/18 tests pasan)
- [ ] Revisar manualmente con un token inválido: ejecutar sync-team y verificar `~/.fyso/hook-debug.log` muestra `API_HTTP_ERROR: GET /api/entities/teams/records -> 401 …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)