### PR TITLE
fix(opencode-plugin): declare bun-types devDependency

### DIFF
--- a/opencode-plugin/package-lock.json
+++ b/opencode-plugin/package-lock.json
@@ -12,6 +12,7 @@
         "fyso-opencode-setup": "src/setup.ts"
       },
       "devDependencies": {
+        "bun-types": "^1.3.13",
         "vitest": "^2.1.8"
       },
       "peerDependencies": {
@@ -937,6 +938,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -1058,6 +1069,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.13.tgz",
+      "integrity": "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/cac": {
@@ -1643,6 +1664,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "13.0.2",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -21,6 +21,7 @@
     "@opencode-ai/plugin": "*"
   },
   "devDependencies": {
+    "bun-types": "^1.3.13",
     "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
## Summary
- `opencode-plugin/tsconfig.json` references `bun-types` in `compilerOptions.types`, but the package was not declared in `devDependencies`.
- On a clean `npm ci`, `npx tsc --noEmit` failed with `TS2688: Cannot find type definition file for 'bun-types'`.
- Add `bun-types ^1.3.13` to `devDependencies` and refresh `package-lock.json`.

## Test plan
- [x] `npm ci` in `opencode-plugin/` resolves `bun-types`.
- [x] `npx tsc --noEmit` no longer reports TS2688 (a pre-existing TS7006 in `src/index.ts:98` is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)