### PR TITLE
test(channel-server): unit tests for parseSseBlock and fetchThread

### DIFF
--- a/bin/channel-server-utils.test.ts
+++ b/bin/channel-server-utils.test.ts
@@ -120,7 +120,7 @@ describe('fetchThread', () => {
     expect(new Set(ids).size).toBe(ids.length);
     // And we should have walked exactly the two unique nodes
     expect(thread).toHaveLength(2);
-    expect(thread.map((m) => m.from).sort()).toEqual(['alice', 'bob']);
+    expect(thread.map((m) => m.from).sort((a, b) => a.localeCompare(b))).toEqual(['alice', 'bob']);
     // Cycle detection should stop the loop early — well below the depth cap
     expect((fetchImpl as any).mock.calls.length).toBe(2);
   });

--- a/bin/channel-server-utils.test.ts
+++ b/bin/channel-server-utils.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseSseBlock, fetchThread } from './channel-server-utils';
+
+// ---------------------------------------------------------------------------
+// parseSseBlock
+// ---------------------------------------------------------------------------
+
+describe('parseSseBlock', () => {
+  it('parses a block with event, data and id', () => {
+    const block = 'event: message.received\ndata: {"hello":"world"}\nid: abc-123';
+    expect(parseSseBlock(block)).toEqual({
+      event: 'message.received',
+      data: '{"hello":"world"}',
+      id: 'abc-123',
+    });
+  });
+
+  it('returns null when the block has no data line', () => {
+    const block = 'event: ping\nid: 42';
+    expect(parseSseBlock(block)).toBeNull();
+  });
+
+  it('concatenates multiple data lines with \\n', () => {
+    const block = 'event: message\ndata: line1\ndata: line2\ndata: line3';
+    const parsed = parseSseBlock(block);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.data).toBe('line1\nline2\nline3');
+  });
+
+  it('keeps the default "message" event when event: line is empty', () => {
+    const block = 'event: \ndata: payload';
+    const parsed = parseSseBlock(block);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.event).toBe('message');
+  });
+
+  it('ignores SSE comment lines starting with ":"', () => {
+    const block = ': this is a comment\n:another comment\ndata: real-data';
+    const parsed = parseSseBlock(block);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.event).toBe('message');
+    expect(parsed!.data).toBe('real-data');
+  });
+
+  it('does not pick up event/data prefixes inside comment lines', () => {
+    // ":event: spoof" starts with ":" so it must be ignored, not parsed as event
+    const block = ':event: spoof\ndata: ok';
+    const parsed = parseSseBlock(block);
+    expect(parsed!.event).toBe('message');
+    expect(parsed!.data).toBe('ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchThread
+// ---------------------------------------------------------------------------
+
+type StoredMessage = {
+  id: string;
+  from_agent: string;
+  subject?: string;
+  payload: any;
+  created_at: string;
+  in_reply_to?: string | null;
+};
+
+function makeFetchImpl(
+  store: Record<string, StoredMessage>,
+  opts: { failingIds?: Set<string> } = {},
+): typeof fetch {
+  const failingIds = opts.failingIds ?? new Set<string>();
+  return vi.fn(async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const m = url.match(/agent-messages\/([^/]+)\/read/);
+    const id = m ? m[1] : '';
+    if (failingIds.has(id)) {
+      return new Response('boom', { status: 500 });
+    }
+    const msg = store[id];
+    if (!msg) return new Response('not found', { status: 404 });
+    return new Response(JSON.stringify({ data: msg }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+}
+
+const baseOpts = {
+  apiUrl: 'https://api.test',
+  tenantSlug: 'acme',
+  apiKey: 'k',
+};
+
+describe('fetchThread', () => {
+  it('walks a 3-message linear chain and returns oldest-first', async () => {
+    const store: Record<string, StoredMessage> = {
+      A: { id: 'A', from_agent: 'alice', payload: { message: 'hi' }, created_at: '2026-01-01T00:00:00Z', in_reply_to: null },
+      B: { id: 'B', from_agent: 'bob', payload: { message: 'hello' }, created_at: '2026-01-01T00:01:00Z', in_reply_to: 'A' },
+      C: { id: 'C', from_agent: 'alice', payload: { message: 'how are you' }, created_at: '2026-01-01T00:02:00Z', in_reply_to: 'B' },
+    };
+
+    const thread = await fetchThread('C', { ...baseOpts, fetchImpl: makeFetchImpl(store) });
+
+    expect(thread.map((m) => m.from)).toEqual(['alice', 'bob', 'alice']);
+    expect(thread.map((m) => m.payload.message)).toEqual(['hi', 'hello', 'how are you']);
+  });
+
+  it('breaks on a circular chain (A→B→A) without producing duplicates', async () => {
+    // Cycle: A.in_reply_to = B, B.in_reply_to = A
+    const store: Record<string, StoredMessage> = {
+      A: { id: 'A', from_agent: 'alice', payload: { message: 'a' }, created_at: '2026-01-01T00:00:00Z', in_reply_to: 'B' },
+      B: { id: 'B', from_agent: 'bob', payload: { message: 'b' }, created_at: '2026-01-01T00:01:00Z', in_reply_to: 'A' },
+    };
+    const fetchImpl = makeFetchImpl(store);
+
+    const thread = await fetchThread('A', { ...baseOpts, fetchImpl });
+
+    // Each message must appear at most once
+    const ids = thread.map((m) => `${m.from}:${m.payload.message}`);
+    expect(new Set(ids).size).toBe(ids.length);
+    // And we should have walked exactly the two unique nodes
+    expect(thread).toHaveLength(2);
+    expect(thread.map((m) => m.from).sort()).toEqual(['alice', 'bob']);
+    // Cycle detection should stop the loop early — well below the depth cap
+    expect((fetchImpl as any).mock.calls.length).toBe(2);
+  });
+
+  it('stops the chain when the HTTP response is not ok', async () => {
+    const store: Record<string, StoredMessage> = {
+      A: { id: 'A', from_agent: 'alice', payload: { message: 'a' }, created_at: '2026-01-01T00:00:00Z', in_reply_to: null },
+      B: { id: 'B', from_agent: 'bob', payload: { message: 'b' }, created_at: '2026-01-01T00:01:00Z', in_reply_to: 'A' },
+    };
+    // Make the first read (B) fail — no thread should be returned
+    const fetchImpl = makeFetchImpl(store, { failingIds: new Set(['B']) });
+
+    const thread = await fetchThread('B', { ...baseOpts, fetchImpl });
+    expect(thread).toEqual([]);
+  });
+
+  it('truncates a chain that exceeds maxDepth', async () => {
+    // Build a 15-deep linear chain m14 → m13 → ... → m0
+    const store: Record<string, StoredMessage> = {};
+    for (let i = 0; i < 15; i++) {
+      store[`m${i}`] = {
+        id: `m${i}`,
+        from_agent: `agent-${i}`,
+        payload: { message: `msg-${i}` },
+        created_at: `2026-01-01T00:${String(i).padStart(2, '0')}:00Z`,
+        in_reply_to: i === 0 ? null : `m${i - 1}`,
+      };
+    }
+    const fetchImpl = makeFetchImpl(store);
+
+    const thread = await fetchThread('m14', { ...baseOpts, fetchImpl });
+    // Default maxDepth = 10
+    expect(thread).toHaveLength(10);
+    expect((fetchImpl as any).mock.calls.length).toBe(10);
+  });
+});

--- a/bin/channel-server-utils.ts
+++ b/bin/channel-server-utils.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure helpers extracted from channel-server.ts so they can be unit tested.
+ *
+ * channel-server.ts is a top-level Bun script with side effects (env reads,
+ * mcp.connect, process.exit) that runs on import — these helpers live here
+ * to keep them importable without triggering that startup.
+ */
+
+export type SseBlock = { event: string; data: string; id?: string };
+
+export type ThreadMessage = {
+  from: string;
+  subject?: string;
+  payload: any;
+  created_at: string;
+};
+
+export type FetchThreadOptions = {
+  apiUrl: string;
+  tenantSlug: string;
+  apiKey: string;
+  /** Override fetch (mainly for tests). Defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+  /** Max chain depth before truncation. Defaults to 10. */
+  maxDepth?: number;
+};
+
+/**
+ * Parse a single SSE event block into { event, data, id }.
+ * Returns null if the block contains no `data:` line.
+ *
+ * Per the SSE spec, an absent or empty `event:` field defaults to "message".
+ * Lines starting with `:` are comments and ignored.
+ */
+export function parseSseBlock(block: string): SseBlock | null {
+  let event = 'message';
+  let data = '';
+  let id: string | undefined;
+
+  for (const line of block.split('\n')) {
+    if (line.startsWith(':')) {
+      // SSE comment line — ignore
+      continue;
+    }
+    if (line.startsWith('event:')) {
+      const value = line.slice(6).trim();
+      // Empty event field falls back to default per SSE spec
+      if (value) event = value;
+    } else if (line.startsWith('data:')) {
+      data += (data ? '\n' : '') + line.slice(5).trim();
+    } else if (line.startsWith('id:')) {
+      id = line.slice(3).trim();
+    }
+  }
+
+  if (!data) return null;
+  return { event, data, id };
+}
+
+/**
+ * Fetch a message by ID and follow the in_reply_to chain to build thread context.
+ * Returns oldest-first. Truncates at maxDepth (default 10) and breaks on cycles.
+ *
+ * Cycle protection: a Set of visited IDs prevents A→B→A loops from producing
+ * duplicated thread entries that would corrupt MCP notification context.
+ */
+export async function fetchThread(
+  messageId: string,
+  options: FetchThreadOptions,
+): Promise<ThreadMessage[]> {
+  const { apiUrl, tenantSlug, apiKey, fetchImpl = fetch, maxDepth = 10 } = options;
+  const thread: ThreadMessage[] = [];
+  const visited = new Set<string>();
+  let currentId: string | null = messageId;
+  let depth = 0;
+
+  while (currentId && depth < maxDepth) {
+    if (visited.has(currentId)) break;
+    visited.add(currentId);
+
+    try {
+      const res = await fetchImpl(
+        `${apiUrl}/api/tenants/${tenantSlug}/agent-messages/${currentId}/read`,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+      );
+      if (!res.ok) break;
+      const data = (await res.json()) as any;
+      const msg = data.data ?? data.message ?? data;
+      thread.unshift({
+        from: msg.from_agent,
+        subject: msg.subject,
+        payload: msg.payload,
+        created_at: msg.created_at,
+      });
+      currentId = msg.in_reply_to ?? null;
+    } catch {
+      break;
+    }
+    depth++;
+  }
+
+  return thread;
+}

--- a/bin/channel-server.ts
+++ b/bin/channel-server.ts
@@ -20,6 +20,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import { parseSseBlock, fetchThread, type ThreadMessage } from './channel-server-utils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -247,62 +248,6 @@ mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a single SSE event block into { event, data, id }.
- * Returns null if the block contains no data line.
- */
-function parseSseBlock(block: string): { event: string; data: string; id?: string } | null {
-  let event = 'message';
-  let data = '';
-  let id: string | undefined;
-
-  for (const line of block.split('\n')) {
-    if (line.startsWith('event:')) {
-      event = line.slice(6).trim();
-    } else if (line.startsWith('data:')) {
-      data += (data ? '\n' : '') + line.slice(5).trim();
-    } else if (line.startsWith('id:')) {
-      id = line.slice(3).trim();
-    }
-  }
-
-  if (!data) return null;
-  return { event, data, id };
-}
-
-/**
- * Fetch a message by ID and follow in_reply_to chain to build thread context.
- * Returns array from oldest to newest. Max 10 messages to avoid runaway chains.
- */
-async function fetchThread(messageId: string): Promise<Array<{ from: string; subject?: string; payload: any; created_at: string }>> {
-  const thread: Array<{ from: string; subject?: string; payload: any; created_at: string }> = [];
-  let currentId: string | null = messageId;
-  let depth = 0;
-
-  while (currentId && depth < 10) {
-    try {
-      const res = await fetch(`${API_URL}/api/tenants/${TENANT_SLUG}/agent-messages/${currentId}/read`, {
-        headers: { Authorization: `Bearer ${API_KEY}` },
-      });
-      if (!res.ok) break;
-      const data = await res.json() as any;
-      const msg = data.data ?? data.message ?? data;
-      thread.unshift({
-        from: msg.from_agent,
-        subject: msg.subject,
-        payload: msg.payload,
-        created_at: msg.created_at,
-      });
-      currentId = msg.in_reply_to ?? null;
-    } catch {
-      break;
-    }
-    depth++;
-  }
-
-  return thread;
-}
-
-/**
  * Build the SSE URL for the given tenant + optional entity filter.
  */
 function buildSseUrl(): string {
@@ -440,9 +385,13 @@ async function startSseBridge(): Promise<() => void> {
             // Format message.received events for readability
             if (parsed.event === 'message.received' && payload.message_id) {
               // Fetch thread context
-              let thread: Array<{ from: string; subject?: string; payload: any; created_at: string }> = [];
+              let thread: ThreadMessage[] = [];
               try {
-                thread = await fetchThread(payload.message_id);
+                thread = await fetchThread(payload.message_id, {
+                  apiUrl: API_URL,
+                  tenantSlug: TENANT_SLUG,
+                  apiKey: API_KEY,
+                });
                 if (thread.length > 0) {
                   payload.thread = thread;
                   payload.thread_length = thread.length;

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@fyso/channel-server",
   "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
## Summary
- Extract `parseSseBlock` and `fetchThread` from `bin/channel-server.ts` into a new `bin/channel-server-utils.ts` so they can be imported without triggering the script's top-level `mcp.connect` / `process.exit` side effects.
- Add `bin/channel-server-utils.test.ts` (vitest) with 10 tests covering the cases listed in the issue.
- Fix two latent bugs uncovered while writing the tests:
  - `parseSseBlock` now keeps the SSE-spec default event name `"message"` when the `event:` line has an empty value (previously it silently overwrote it with `""`).
  - `fetchThread` tracks visited IDs in a `Set` so a cyclic `in_reply_to` chain (e.g. A→B→A) breaks immediately instead of running until the depth cap and emitting duplicated thread entries that would corrupt MCP notification context.

## Test plan
- [x] `cd bin && npx vitest run` — 10/10 pass
- [x] `parseSseBlock` covers: event+data+id, missing data, multi-line data, empty event, comment lines, comment-prefixed spoof
- [x] `fetchThread` covers: 3-message linear chain (oldest-first), A→B→A cycle (no duplicates, exits early), non-ok HTTP truncates, 15-deep chain truncated to 10
- [x] `bin/channel-server.ts` updated to import the helpers from the new module and pass config explicitly to `fetchThread`

🤖 Generated with [Claude Code](https://claude.com/claude-code)