### PR TITLE
test(sync-team): cover writeMarkerSection to prevent file corruption

### DIFF
--- a/opencode-plugin/src/tools/sync-team.test.ts
+++ b/opencode-plugin/src/tools/sync-team.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, readFile, writeFile, rm } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+import {
+  writeMarkerSection,
+  FYSO_MARKER_START as START,
+  FYSO_MARKER_END as END,
+} from "./sync-team"
+
+describe("writeMarkerSection", () => {
+  let dir: string
+  let filePath: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "fyso-sync-team-"))
+    filePath = join(dir, "CLAUDE.md")
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("creates a new file with markers and content when no file exists", async () => {
+    await writeMarkerSection(filePath, "hello team")
+
+    const result = await readFile(filePath, "utf-8")
+    expect(result).toBe(`${START}\nhello team\n${END}\n`)
+  })
+
+  it("appends a section without modifying original content when file has no markers", async () => {
+    const original = "# Existing project notes\n\nSome handwritten content.\n"
+    await writeFile(filePath, original)
+
+    await writeMarkerSection(filePath, "team prompt")
+
+    const result = await readFile(filePath, "utf-8")
+    expect(result.startsWith(original)).toBe(true)
+    expect(result).toContain(`${START}\nteam prompt\n${END}`)
+  })
+
+  it("replaces existing section while preserving content before START and after END", async () => {
+    const before = "# Project\n\nIntro paragraph.\n\n"
+    const after = "\n\n## Manual notes\nDeveloper-edited content below the section.\n"
+    await writeFile(filePath, `${before}${START}\nold content\n${END}${after}`)
+
+    await writeMarkerSection(filePath, "new content")
+
+    const result = await readFile(filePath, "utf-8")
+    expect(result).toBe(`${before}${START}\nnew content\n${END}${after}`)
+    expect(result.startsWith(before)).toBe(true)
+    expect(result.endsWith(after)).toBe(true)
+  })
+
+  it("preserves content after END marker exactly, including newlines and trailing text", async () => {
+    const after = "\n\n\n## Trailing section\nLine A\nLine B\n"
+    await writeFile(filePath, `${START}\nold\n${END}${after}`)
+
+    await writeMarkerSection(filePath, "replacement")
+
+    const result = await readFile(filePath, "utf-8")
+    expect(result.endsWith(after)).toBe(true)
+    expect(result).toBe(`${START}\nreplacement\n${END}${after}`)
+  })
+
+  it("throws and does not modify the file when END marker appears before START marker", async () => {
+    const malformed = `intro\n${END}\norphan content\n${START}\nmore content\n`
+    await writeFile(filePath, malformed)
+
+    await expect(writeMarkerSection(filePath, "anything")).rejects.toThrow(/malformed markers/i)
+
+    const onDisk = await readFile(filePath, "utf-8")
+    expect(onDisk).toBe(malformed)
+  })
+
+  it("is idempotent: calling twice with the same content produces the same file output", async () => {
+    const original = "# Header\nSome content before\n"
+    await writeFile(filePath, original)
+
+    await writeMarkerSection(filePath, "team prompt")
+    const firstPass = await readFile(filePath, "utf-8")
+
+    await writeMarkerSection(filePath, "team prompt")
+    const secondPass = await readFile(filePath, "utf-8")
+
+    expect(secondPass).toBe(firstPass)
+  })
+})

--- a/opencode-plugin/src/tools/sync-team.ts
+++ b/opencode-plugin/src/tools/sync-team.ts
@@ -38,17 +38,24 @@ function firstLineOf(text: string, fallback: string): string {
   return line || fallback
 }
 
-async function writeMarkerSection(filePath: string, content: string): Promise<void> {
-  const START = "<!-- FYSO TEAM START -->"
-  const END = "<!-- FYSO TEAM END -->"
-  const section = `${START}\n${content}\n${END}`
+export const FYSO_MARKER_START = "<!-- FYSO TEAM START -->"
+export const FYSO_MARKER_END = "<!-- FYSO TEAM END -->"
+
+export async function writeMarkerSection(filePath: string, content: string): Promise<void> {
+  const section = `${FYSO_MARKER_START}\n${content}\n${FYSO_MARKER_END}`
 
   if (existsSync(filePath)) {
     const existing = await readFile(filePath, "utf-8")
-    const startIdx = existing.indexOf(START)
-    const endIdx = existing.indexOf(END)
+    const startIdx = existing.indexOf(FYSO_MARKER_START)
+    const endIdx = existing.lastIndexOf(FYSO_MARKER_END)
     if (startIdx !== -1 && endIdx !== -1) {
-      const updated = existing.slice(0, startIdx) + section + existing.slice(endIdx + END.length)
+      if (endIdx < startIdx) {
+        throw new Error(
+          `writeMarkerSection: malformed markers in ${filePath} — END appears before START. Refusing to modify file to avoid corruption.`,
+        )
+      }
+      const updated =
+        existing.slice(0, startIdx) + section + existing.slice(endIdx + FYSO_MARKER_END.length)
       await writeFile(filePath, updated)
       return
     }


### PR DESCRIPTION
## Summary
- Add 6 vitest cases for `writeMarkerSection` in `opencode-plugin/src/tools/sync-team.ts` covering new file, no markers, replace, content preservation after END, malformed markers, and idempotency.
- Export `writeMarkerSection` (and the marker constants) so it is testable from outside the module.
- Harden splice logic against silent corruption: switch END lookup to `lastIndexOf` so duplicate marker pairs collapse cleanly on next sync, and throw a clear error when END appears before START instead of producing garbled content.

## Test plan
- [x] `cd opencode-plugin && npx vitest run sync-team.test` — 6/6 pass
- [x] `cd opencode-plugin && npx vitest run` — full suite 24/24 pass