### PR TITLE
feat: /fyso:create-team wizard + fyso-create-team OpenCode tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Universal Fyso plugin for AI coding agents. Build complete business apps from co
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| **Skills** | 16 | Slash commands (`/fyso:plan`, `/fyso:build`, etc.) — shared across both platforms |
+| **Skills** | 17 | Slash commands (`/fyso:plan`, `/fyso:build`, etc.) — shared across both platforms |
 | **Agents** | 5 | Specialized subagents (architect, designer, builder, verifier, ui-architect) |
 | **Team Sync** | 1 | Sync Fyso agent teams to local directories |
 | **Tracking** | hooks | Session tracking, agent dispatch, heartbeat |
@@ -104,7 +104,7 @@ On first use, the MCP server opens an OAuth flow to connect your Fyso account.
 
 ### Full Skill List
 
-All 16 skills are top-level slash commands. Several skills accept subcommands (shown in the second column).
+All 17 skills are top-level slash commands. Several skills accept subcommands (shown in the second column).
 
 | Skill | Subcommands | Description |
 |-------|-------------|-------------|
@@ -124,6 +124,7 @@ All 16 skills are top-level slash commands. Several skills accept subcommands (s
 | `test` | — | Test runner for rules |
 | `welcome` | — | Guided onboarding |
 | `sync-team` | — | Sync Fyso agent teams to local directories |
+| `create-team` | — | Create a new Fyso agent team from the plugin (wizard) |
 
 ## Agents
 
@@ -150,6 +151,15 @@ Sync agent teams defined in Fyso to your local environment:
 4. Agent files are created for both platforms:
    - Claude Code: `.claude/agents/{name}.md`
    - OpenCode: `.opencode/agents/{name}.md`
+
+## Team Creation
+
+Create new agent teams without leaving your IDE:
+
+- **Claude Code:** `/fyso:create-team` runs a wizard that asks for name, description, prompt, and which agents to assign.
+- **OpenCode:** ask the agent to use the `fyso-create-team` tool (call it with no args to list available agents, then again with `name`, `prompt`, `description`, and `agent_ids` to persist the team).
+
+Both flows POST to `/api/entities/teams/records` and `/api/entities/team_agents/records`. After creation, run `sync-team` to pull the new team into the current project.
 
 ## Tracking
 

--- a/opencode-plugin/src/index.ts
+++ b/opencode-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { tool } from "@opencode-ai/plugin"
 import { createTracker } from "./tracking"
 import { readConfig, readTeamConfig } from "./config"
 import { listTeams, fetchTeamAgents, syncAgentsToDirectory } from "./tools/sync-team"
+import { listAgents, createTeam, assignAgents } from "./tools/create-team"
 import { writeFile, mkdir } from "fs/promises"
 import { join } from "path"
 
@@ -91,6 +92,70 @@ export const FysoPlugin: Plugin = async (ctx) => {
             "- **OpenCode**: via @ mention",
           ]
           return summary.join("\n")
+        },
+      }),
+
+      "fyso-create-team": tool({
+        description:
+          "Create a new Fyso agent team. Call with no args to list available agents for selection; call with name to create the team. Optionally assigns initial agents.",
+        args: {
+          name: tool.schema
+            .string()
+            .optional()
+            .describe("Team name. If omitted, the tool lists available agents instead."),
+          prompt: tool.schema
+            .string()
+            .optional()
+            .describe("Team system prompt -- shared instructions for all agents on the team."),
+          description: tool.schema
+            .string()
+            .optional()
+            .describe("Short human-readable description of the team."),
+          agent_ids: tool.schema
+            .array(tool.schema.string())
+            .optional()
+            .describe("IDs of agents to assign to the team at creation."),
+        },
+        async execute(args) {
+          const config = await readConfig()
+          if (!config) {
+            return "No Fyso credentials found. Run the sync-team skill first to configure credentials at ~/.fyso/config.json, or visit https://agent-ui-sites.fyso.dev/ to get your token."
+          }
+
+          if (!args.name) {
+            const agents = await listAgents(config)
+            if (!agents.length) {
+              return "No agents found in your Fyso account. Create agents in the Fyso dashboard before assembling a team."
+            }
+            const list = agents
+              .map((a, i) => `${i + 1}. **${a.display_name}** (${a.role}) -- ID: ${a.id}`)
+              .join("\n")
+            return `Available agents to assign:\n\n${list}\n\nCall this tool again with name, prompt, description, and agent_ids to create the team.`
+          }
+
+          const created = await createTeam(config, {
+            name: args.name,
+            prompt: args.prompt,
+            description: args.description,
+          })
+
+          let assignedCount = 0
+          if (args.agent_ids?.length) {
+            const assigned = await assignAgents(config, created.id, args.agent_ids)
+            assignedCount = assigned.length
+          }
+
+          const summary = [
+            `Team **${created.name}** created (ID: ${created.id}).`,
+            created.description ? `Description: ${created.description}` : "",
+            created.prompt ? "Team prompt saved." : "No team prompt set.",
+            assignedCount
+              ? `Assigned ${assignedCount} agent(s) to the team.`
+              : "No agents assigned yet -- use the Fyso dashboard or call this tool again with agent_ids.",
+            "",
+            "Run /fyso:sync-team (Claude Code) or the fyso-sync-team tool (OpenCode) to pull this team into the current project.",
+          ]
+          return summary.filter(Boolean).join("\n")
         },
       }),
     },

--- a/opencode-plugin/src/tools/create-team.test.ts
+++ b/opencode-plugin/src/tools/create-team.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { listAgents, createTeam, assignAgents } from "./create-team"
+import { ApiRequestError, type FysoConfig } from "../config"
+
+const config: FysoConfig = {
+  token: "t",
+  tenant_id: "tenant",
+  api_url: "https://api.test",
+}
+
+function mockJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("listAgents", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("normalizes agent records and skips entries without an id", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockJson({
+        data: {
+          items: [
+            { id: "a1", name: "cero", display_name: "Cero", role: "developer" },
+            { name: "ghost" },
+            { id: "a2", name: "vigia" },
+          ],
+        },
+      }),
+    )
+
+    const result = await listAgents(config)
+    expect(result).toEqual([
+      { id: "a1", name: "cero", display_name: "Cero", role: "developer" },
+      { id: "a2", name: "vigia", display_name: "vigia", role: "assistant" },
+    ])
+  })
+
+  it("returns an empty array when the API returns no items", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockJson({ data: { items: [] } }))
+    expect(await listAgents(config)).toEqual([])
+  })
+})
+
+describe("createTeam", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("POSTs only the provided fields and returns the created team", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockJson({ data: { id: "team_1", name: "devs", prompt: "hi" } }),
+    )
+
+    const team = await createTeam(config, { name: "devs", prompt: "hi" })
+
+    expect(team).toEqual({ id: "team_1", name: "devs", prompt: "hi", description: undefined })
+    const call = vi.mocked(globalThis.fetch).mock.calls[0]!
+    const init = call[1] as RequestInit
+    expect(init.method).toBe("POST")
+    expect(JSON.parse(init.body as string)).toEqual({ name: "devs", prompt: "hi" })
+  })
+
+  it("throws when the API response is missing the team id", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockJson({ data: {} }))
+    await expect(createTeam(config, { name: "x" })).rejects.toThrow(/missing team id/)
+  })
+
+  it("surfaces ApiRequestError from the underlying request", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response("bad", { status: 422 }))
+    await expect(createTeam(config, { name: "x" })).rejects.toBeInstanceOf(ApiRequestError)
+  })
+})
+
+describe("assignAgents", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("creates one team_agents record per agent id and returns their ids", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(mockJson({ data: { id: "ta_1" } }))
+      .mockResolvedValueOnce(mockJson({ data: { id: "ta_2" } }))
+
+    const ids = await assignAgents(config, "team_1", ["agent_a", "agent_b"])
+    expect(ids).toEqual(["ta_1", "ta_2"])
+
+    const bodies = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.map((c) => JSON.parse((c[1] as RequestInit).body as string))
+    expect(bodies).toEqual([
+      { team: "team_1", agent: "agent_a" },
+      { team: "team_1", agent: "agent_b" },
+    ])
+  })
+})

--- a/opencode-plugin/src/tools/create-team.ts
+++ b/opencode-plugin/src/tools/create-team.ts
@@ -1,0 +1,79 @@
+import { apiRequest, type FysoConfig } from "../config"
+
+export interface AgentSummary {
+  id: string
+  name: string
+  display_name: string
+  role: string
+}
+
+export interface CreateTeamInput {
+  name: string
+  prompt?: string
+  description?: string
+  agent_ids?: string[]
+}
+
+export interface CreatedTeam {
+  id: string
+  name: string
+  prompt?: string
+  description?: string
+}
+
+export async function listAgents(config: FysoConfig): Promise<AgentSummary[]> {
+  const resp = (await apiRequest(config, "GET", "/api/entities/agents/records")) as {
+    data?: { items?: Array<Partial<AgentSummary> & { id?: string }> }
+  }
+  const items = resp?.data?.items || []
+  return items
+    .filter((a): a is AgentSummary & { id: string } => typeof a.id === "string")
+    .map((a) => ({
+      id: a.id,
+      name: a.name || "unnamed",
+      display_name: a.display_name || a.name || "Unnamed Agent",
+      role: a.role || "assistant",
+    }))
+}
+
+export async function createTeam(
+  config: FysoConfig,
+  input: CreateTeamInput,
+): Promise<CreatedTeam> {
+  const body: Record<string, unknown> = { name: input.name }
+  if (input.prompt) body.prompt = input.prompt
+  if (input.description) body.description = input.description
+
+  const resp = (await apiRequest(config, "POST", "/api/entities/teams/records", body)) as {
+    data?: Partial<CreatedTeam> & { id?: string }
+    id?: string
+  }
+  const record = resp?.data ?? resp
+  const id = (record as { id?: string })?.id
+  if (!id) {
+    throw new Error("createTeam: API response missing team id")
+  }
+  return {
+    id,
+    name: (record as CreatedTeam).name ?? input.name,
+    prompt: (record as CreatedTeam).prompt ?? input.prompt,
+    description: (record as CreatedTeam).description ?? input.description,
+  }
+}
+
+export async function assignAgents(
+  config: FysoConfig,
+  teamId: string,
+  agentIds: string[],
+): Promise<string[]> {
+  const assigned: string[] = []
+  for (const agentId of agentIds) {
+    const resp = (await apiRequest(config, "POST", "/api/entities/team_agents/records", {
+      team: teamId,
+      agent: agentId,
+    })) as { data?: { id?: string }; id?: string }
+    const id = resp?.data?.id ?? resp?.id
+    if (id) assigned.push(id)
+  }
+  return assigned
+}

--- a/skills/create-team/SKILL.md
+++ b/skills/create-team/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: create-team
+description: Create a new Fyso agent team from the plugin. Collects name, prompt, description, and initial agents, persists via the Fyso API, then runs sync-team so the new team is immediately available locally.
+user-invocable: true
+---
+
+# Create a Fyso Team
+
+Follow these steps to create a new agent team in Fyso and make it available in the current project.
+
+## Config
+
+Reuses the same credentials as `sync-team`:
+
+- `~/.fyso/config.json` -- global credentials (`token`, `tenant_id`, `api_url`)
+
+If the file does not exist, send the user through Step 1 of the `sync-team` skill to set it up, then come back.
+
+## Step 1 -- Confirm credentials
+
+Read `~/.fyso/config.json`. If missing or `token` is empty, tell the user:
+
+> No encontre tus credenciales de Fyso en `~/.fyso/config.json`. Corre primero `/fyso:sync-team` para guardar tu token, despues volve a este wizard.
+
+Stop. Do not proceed without a token.
+
+## Step 2 -- Collect team details
+
+Ask the user, one prompt at a time, in Spanish:
+
+1. **Nombre del equipo** (required). Slug-friendly, e.g. `developer-team`, `support-squad`.
+2. **Descripcion corta** (optional). One-line summary shown in the dashboard.
+3. **Prompt del equipo** (optional). Shared system prompt for every agent in the team. Tell the user they can paste a multi-line prompt or type `skip`.
+
+Validate that the name is non-empty before continuing. If the user types `skip` for an optional field, store an empty value and move on.
+
+## Step 3 -- List available agents
+
+Fetch existing agents the user can assign to the team:
+
+```
+curl -s "https://api.fyso.dev/api/entities/agents/records" \
+  -H "Authorization: Bearer {TOKEN}" \
+  -H "X-Tenant-ID: fyso-world-fcecd"
+```
+
+Records live at `data.items`. Each item exposes at least `id`, `name`, `display_name`, `role`.
+
+Present them as a numbered list, e.g.:
+
+```
+1. **Cero** (developer) -- ID: 9f0c...
+2. **Unitas** (qa) -- ID: 7ab1...
+3. **Vigia** (security) -- ID: 41ed...
+```
+
+Ask the user which agents to assign. Accept:
+
+- a comma-separated list of numbers (`1,3`)
+- a comma-separated list of agent names
+- `none` to create the team with zero agents (they can add later from the dashboard)
+
+If the list is empty, tell the user no agents exist in their account and that they can create the team anyway and assign agents later.
+
+## Step 4 -- Confirm before creating
+
+Show a summary of what is about to be created:
+
+```
+Voy a crear el equipo:
+  Nombre: {name}
+  Descripcion: {description or "(sin descripcion)"}
+  Prompt: {first 80 chars of prompt or "(sin prompt)"}
+  Agentes: {comma-separated display names, or "ninguno"}
+```
+
+Ask for confirmation. Only proceed on an explicit yes.
+
+## Step 5 -- Create the team
+
+POST to the teams endpoint:
+
+```
+curl -s -X POST "https://api.fyso.dev/api/entities/teams/records" \
+  -H "Authorization: Bearer {TOKEN}" \
+  -H "X-Tenant-ID: fyso-world-fcecd" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"{NAME}","prompt":"{PROMPT}","description":"{DESCRIPTION}"}'
+```
+
+Omit `prompt` and `description` from the JSON body when empty. The response contains the new team in `data` (or at the top level) with an `id` field. Save the `id` -- you need it for the next step.
+
+If the API returns a non-2xx response, surface the status code and body snippet to the user, then stop.
+
+## Step 6 -- Assign agents
+
+For each agent ID the user picked, POST one record to `team_agents`:
+
+```
+curl -s -X POST "https://api.fyso.dev/api/entities/team_agents/records" \
+  -H "Authorization: Bearer {TOKEN}" \
+  -H "X-Tenant-ID: fyso-world-fcecd" \
+  -H "Content-Type: application/json" \
+  -d '{"team":"{TEAM_ID}","agent":"{AGENT_ID}"}'
+```
+
+If a single assignment fails, report the failure and keep going with the rest. At the end, tell the user how many succeeded and which (if any) failed.
+
+If the user picked `none`, skip this step.
+
+## Step 7 -- Sync the team locally
+
+The team only exists in the dashboard until it is synced. Run the `sync-team` skill with the newly created `team_id` so the agent files are written to:
+
+- Claude Code: `.claude/agents/{name}.md`
+- OpenCode: `.opencode/agents/{name}.md`
+- Team prompt: `.claude/CLAUDE.md` and `opencode.md` (between the `<!-- FYSO TEAM START -->` markers)
+
+If the team has zero agents, skip the sync and tell the user the team is empty -- they can add agents in the dashboard and rerun `/fyso:sync-team` later.
+
+## Step 8 -- Report results
+
+Print a final summary:
+
+- Team name and ID
+- Description and prompt (or "no configurado")
+- Number of agents assigned (and any failures)
+- The local files written during sync, if any
+- The dashboard URL: `https://agent-ui-sites.fyso.dev/`
+
+## OpenCode shortcut
+
+In OpenCode the same flow is available via the `fyso-create-team` tool. The tool exposes two modes:
+
+- Called without `name`: returns the list of available agents.
+- Called with `name` (and optional `prompt`, `description`, `agent_ids`): creates the team in one call.
+
+The skill is preferred when the user wants the wizard experience; the tool is preferred when the agent already has all the inputs in hand.


### PR DESCRIPTION
## Summary
- Adds `/fyso:create-team` skill: interactive wizard that collects team name, description, prompt and initial agent assignments, then persists via `POST /api/entities/teams/records` and `POST /api/entities/team_agents/records`.
- Adds matching `fyso-create-team` OpenCode tool with two modes: call with no args to list available agents; call with `name` (plus optional `prompt`/`description`/`agent_ids`) to create the team in one shot.
- Extracts pure helpers (`listAgents`, `createTeam`, `assignAgents`) in `opencode-plugin/src/tools/create-team.ts` and covers them with Vitest unit tests.
- Updates README skill table and adds a "Team Creation" section.

Closes the Discord request from @szapata (gw_7406ae23775ea452) for creating teams from inside the plugin instead of only syncing them.

## Test plan
- [x] `cd opencode-plugin && npm test` — 24 tests passing (3 new files: 6 tests for create-team helpers)
- [ ] Manual: run `/fyso:create-team` in Claude Code, walk through wizard against a staging tenant
- [ ] Manual: in OpenCode, ask the agent to use `fyso-create-team` without args, then with `{name, agent_ids}`
- [ ] Manual: confirm the new team shows up in `/fyso:sync-team` and the agent files are written under `.claude/agents/` and `.opencode/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)