### PR TITLE
chore(release): bump plugin to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "fyso",
       "source": "./",
       "description": "Universal Fyso plugin for AI coding agents. 16 skills, 5 agents, team sync, tracking, and auto-synced reference docs. Works with Claude Code and OpenCode.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": { "name": "Fyso" },
       "homepage": "https://fyso.dev",
       "repository": "https://github.com/fyso-dev/fyso-plugin",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fyso",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Universal Fyso plugin for AI coding agents. 16 skills, 5 agents, hooks, team sync, tracking, and auto-synced reference docs. Works with Claude Code and OpenCode.",
   "author": {
     "name": "Fyso",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fyso/opencode-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Official Fyso plugin for OpenCode — tracking, team sync, and session management for building ERPs with natural language",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump `version` from `2.0.0` to `2.1.0` in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` y `opencode-plugin/package.json`.
- PR #74 introdujo el skill `/fyso:create-team` y la herramienta OpenCode `fyso-create-team` (nueva funcionalidad → bump minor según semver).
- Tras el merge de #74 la versión publicada no se había incrementado, por lo que Claude no ofrecía actualización a los usuarios.

## Test plan
- [ ] Confirmar que Claude detecta la nueva versión 2.1.0 en el marketplace.
- [ ] Actualizar el plugin desde Claude y verificar que el skill `/fyso:create-team` queda disponible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)