### PR TITLE
fix(create-team): tolerate partial failures in assignAgents

### DIFF
--- a/opencode-plugin/src/index.ts
+++ b/opencode-plugin/src/index.ts
@@ -140,9 +140,16 @@ export const FysoPlugin: Plugin = async (ctx) => {
           })
 
           let assignedCount = 0
+          let failedLines: string[] = []
           if (args.agent_ids?.length) {
-            const assigned = await assignAgents(config, created.id, args.agent_ids)
-            assignedCount = assigned.length
+            const result = await assignAgents(config, created.id, args.agent_ids)
+            assignedCount = result.assigned_agent_ids.length
+            if (result.failed.length) {
+              failedLines = [
+                `Failed to assign ${result.failed.length} agent(s):`,
+                ...result.failed.map((f) => `- ${f.agent_id}: ${f.message}`),
+              ]
+            }
           }
 
           const summary = [
@@ -152,6 +159,7 @@ export const FysoPlugin: Plugin = async (ctx) => {
             assignedCount
               ? `Assigned ${assignedCount} agent(s) to the team.`
               : "No agents assigned yet -- use the Fyso dashboard or call this tool again with agent_ids.",
+            ...failedLines,
             "",
             "Run /fyso:sync-team (Claude Code) or the fyso-sync-team tool (OpenCode) to pull this team into the current project.",
           ]

--- a/opencode-plugin/src/tools/create-team.test.ts
+++ b/opencode-plugin/src/tools/create-team.test.ts
@@ -95,8 +95,10 @@ describe("assignAgents", () => {
       .mockResolvedValueOnce(mockJson({ data: { id: "ta_1" } }))
       .mockResolvedValueOnce(mockJson({ data: { id: "ta_2" } }))
 
-    const ids = await assignAgents(config, "team_1", ["agent_a", "agent_b"])
-    expect(ids).toEqual(["ta_1", "ta_2"])
+    const result = await assignAgents(config, "team_1", ["agent_a", "agent_b"])
+    expect(result.assigned).toEqual(["ta_1", "ta_2"])
+    expect(result.assigned_agent_ids).toEqual(["agent_a", "agent_b"])
+    expect(result.failed).toEqual([])
 
     const bodies = vi
       .mocked(globalThis.fetch)
@@ -105,5 +107,32 @@ describe("assignAgents", () => {
       { team: "team_1", agent: "agent_a" },
       { team: "team_1", agent: "agent_b" },
     ])
+  })
+
+  it("continues with the remaining agents when one assignment fails", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(mockJson({ data: { id: "ta_1" } }))
+      .mockResolvedValueOnce(new Response("invalid agent", { status: 422 }))
+      .mockResolvedValueOnce(mockJson({ data: { id: "ta_3" } }))
+
+    const result = await assignAgents(config, "team_1", ["agent_a", "agent_bad", "agent_c"])
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(3)
+    expect(result.assigned).toEqual(["ta_1", "ta_3"])
+    expect(result.assigned_agent_ids).toEqual(["agent_a", "agent_c"])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0]!.agent_id).toBe("agent_bad")
+    expect(result.failed[0]!.message).toMatch(/422/)
+  })
+
+  it("returns all agents as failed when every assignment fails", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response("nope", { status: 500 }))
+      .mockResolvedValueOnce(new Response("nope", { status: 500 }))
+
+    const result = await assignAgents(config, "team_1", ["agent_a", "agent_b"])
+    expect(result.assigned).toEqual([])
+    expect(result.assigned_agent_ids).toEqual([])
+    expect(result.failed.map((f) => f.agent_id)).toEqual(["agent_a", "agent_b"])
   })
 })

--- a/opencode-plugin/src/tools/create-team.ts
+++ b/opencode-plugin/src/tools/create-team.ts
@@ -61,19 +61,38 @@ export async function createTeam(
   }
 }
 
+export interface AssignAgentFailure {
+  agent_id: string
+  message: string
+}
+
+export interface AssignAgentsResult {
+  assigned: string[]
+  assigned_agent_ids: string[]
+  failed: AssignAgentFailure[]
+}
+
 export async function assignAgents(
   config: FysoConfig,
   teamId: string,
   agentIds: string[],
-): Promise<string[]> {
+): Promise<AssignAgentsResult> {
   const assigned: string[] = []
+  const assignedAgentIds: string[] = []
+  const failed: AssignAgentFailure[] = []
   for (const agentId of agentIds) {
-    const resp = (await apiRequest(config, "POST", "/api/entities/team_agents/records", {
-      team: teamId,
-      agent: agentId,
-    })) as { data?: { id?: string }; id?: string }
-    const id = resp?.data?.id ?? resp?.id
-    if (id) assigned.push(id)
+    try {
+      const resp = (await apiRequest(config, "POST", "/api/entities/team_agents/records", {
+        team: teamId,
+        agent: agentId,
+      })) as { data?: { id?: string }; id?: string }
+      const id = resp?.data?.id ?? resp?.id
+      if (id) assigned.push(id)
+      assignedAgentIds.push(agentId)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      failed.push({ agent_id: agentId, message })
+    }
   }
-  return assigned
+  return { assigned, assigned_agent_ids: assignedAgentIds, failed }
 }


### PR DESCRIPTION
## Summary
- `assignAgents` ahora envuelve cada `apiRequest` en `try/catch` y acumula tanto los IDs asignados como los fallos, en vez de abortar al primer error.
- Devuelve `{ assigned, assigned_agent_ids, failed }` para que el caller distinga éxitos y fallos por agente.
- El tool `fyso-create-team` muestra el conteo de asignaciones exitosas y una lista de IDs fallidos con su mensaje, alineándose con lo que el skill `create-team` ya prometía al usuario.

## Test plan
- [x] `npx vitest run` (61 tests, incluidos 2 nuevos casos de `assignAgents`: fallo parcial y fallo total)
- [ ] Verificación manual: crear un equipo con 3 agentes donde uno tiene ID inválido y confirmar que los otros 2 se asignan y se reporta el fallo

🤖 Generated with [Claude Code](https://claude.com/claude-code)