### PR TITLE
refactor(hooks): extract remaining duplicated Python into _tracking_lib

### DIFF
--- a/hooks/_tracking_lib.py
+++ b/hooks/_tracking_lib.py
@@ -7,6 +7,10 @@ Single source of truth for:
 - infer_model_family(model)
 - calculate_cost(family, ...)
 - parse_transcript_usage(path) — JSONL session token accumulator.
+- summarize_transcript_lines(...) — tool_use + last assistant text extractor.
+- load_config() / load_team_name(cwd) — config + team.json readers.
+- is_debug() / debug_log(message) — ~/.fyso/debug flag-gated logger.
+- send_tracking_payload(...) — HTTP POST to /api/entities/tracking/records.
 
 The PRICING source-of-truth file can be overridden via the PRICING_FILE
 environment variable; otherwise it resolves relative to this file.
@@ -14,6 +18,7 @@ environment variable; otherwise it resolves relative to this file.
 
 import json
 import os
+import urllib.request
 
 
 _DEFAULT_PRICING_PATH = os.path.normpath(
@@ -134,3 +139,111 @@ def parse_transcript_usage(transcript_path, retain_lines=False):
     except Exception:
         pass
     return result
+
+
+def summarize_transcript_lines(lines, tools_dedup_window, text_threshold, text_truncate=None):
+    """Extract ``(tools_used, last_text)`` from a slice of JSONL transcript lines.
+
+    Both tracking.sh (session_end summary) and heartbeat.sh (recent activity)
+    share this walk but with different knobs:
+
+    - ``tools_dedup_window``: a tool name is appended only if absent from the
+      last N entries of ``tools_used`` (5 for tracking, 3 for heartbeat).
+    - ``text_threshold``: minimum stripped length for assistant text to count
+      (10 for tracking, 5 for heartbeat).
+    - ``text_truncate``: if set, ``last_text`` is sliced to this many chars
+      (None for tracking — caller truncates later; 100 for heartbeat).
+    """
+    tools_used = []
+    last_text = ""
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except Exception:
+            continue
+        msg = entry.get("message", {})
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for c in content:
+            if not isinstance(c, dict):
+                continue
+            if c.get("type") == "tool_use":
+                name = c.get("name", "")
+                if name and name not in tools_used[-tools_dedup_window:]:
+                    tools_used.append(name)
+            elif c.get("type") == "text" and msg.get("role") == "assistant":
+                t = c.get("text", "").strip()
+                if t and len(t) > text_threshold:
+                    last_text = t[:text_truncate] if text_truncate else t
+    return tools_used, last_text
+
+
+def load_config(path=None):
+    """Read ``~/.fyso/config.json``. Returns ``dict`` or ``None`` on missing/error."""
+    path = path or os.path.expanduser("~/.fyso/config.json")
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def load_team_name(cwd):
+    """Read ``team_name`` from ``<cwd>/.fyso/team.json``. Returns ``''`` on missing/error."""
+    if not cwd:
+        return ""
+    try:
+        team_path = os.path.join(cwd, ".fyso", "team.json")
+        if os.path.exists(team_path):
+            with open(team_path) as tf:
+                return json.load(tf).get("team_name", "") or ""
+    except Exception:
+        pass
+    return ""
+
+
+_DEBUG_FLAG_PATH = os.path.expanduser("~/.fyso/debug")
+_DEBUG_LOG_PATH = os.path.expanduser("~/.fyso/hook-debug.log")
+
+
+def is_debug():
+    """True iff the ``~/.fyso/debug`` flag file exists."""
+    return os.path.exists(_DEBUG_FLAG_PATH)
+
+
+def debug_log(message):
+    """Append ``message`` to ``~/.fyso/hook-debug.log`` iff debug flag is set.
+
+    The caller is responsible for line terminators so multi-line entries stay
+    formatted as before.
+    """
+    if not is_debug():
+        return
+    try:
+        with open(_DEBUG_LOG_PATH, "a") as dl:
+            dl.write(message)
+    except Exception:
+        pass
+
+
+def send_tracking_payload(api_url, token, tenant, payload_bytes, timeout=5):
+    """POST raw JSON bytes to ``<api_url>/api/entities/tracking/records``.
+
+    Returns ``(status_code, body_text)``. Raises on network/HTTP errors so the
+    caller can log them through ``debug_log``.
+    """
+    req = urllib.request.Request(
+        f"{api_url}/api/entities/tracking/records",
+        data=payload_bytes,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Tenant-ID": tenant,
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    return resp.status, resp.read().decode()

--- a/hooks/heartbeat.sh
+++ b/hooks/heartbeat.sh
@@ -35,33 +35,37 @@ while true; do
   python3 << 'PYEOF'
 import json, os, sys, datetime
 
-# Import shared tracking library (PRICING + infer_model_family + cost + transcript parser)
+# Import shared tracking library (single source of truth for config/team/
+# transcript parsing/model family/cost/HTTP send/debug logging).
 sys.path.insert(0, os.environ.get("FYSO_HOOKS_DIR", os.path.dirname(os.path.abspath(__file__))))
 try:
-    from _tracking_lib import load_pricing, infer_model_family, calculate_cost, parse_transcript_usage
+    from _tracking_lib import (
+        load_pricing,
+        infer_model_family,
+        calculate_cost,
+        parse_transcript_usage,
+        summarize_transcript_lines,
+        load_config,
+        load_team_name,
+        debug_log,
+        is_debug,
+        send_tracking_payload,
+    )
 except Exception:
     sys.exit(0)
 
-config_path = os.path.expanduser("~/.fyso/config.json")
-try:
-    cfg = json.load(open(config_path))
-except:
+cfg = load_config()
+if not cfg:
     sys.exit(0)
 
 token = cfg.get("token", "")
 tenant = cfg.get("tenant_id", "")
 api_url = cfg.get("api_url", "https://api.fyso.dev")
-team_name = ""
-try:
-    team_path = os.path.join(os.environ.get("CWD", os.getcwd()), ".fyso", "team.json")
-    if os.path.exists(team_path):
-        team_name = json.load(open(team_path)).get("team_name", "")
-except:
-    pass
 user_email = cfg.get("user_email", "")
 session_id = os.environ.get("SESSION_ID", "")
 transcript = os.environ.get("TRANSCRIPT", "")
 cwd = os.environ.get("CWD", "")
+team_name = load_team_name(cwd or os.getcwd())
 
 if not token or not tenant or not transcript:
     sys.exit(0)
@@ -71,34 +75,18 @@ if not token or not tenant or not transcript:
 _t = parse_transcript_usage(transcript, retain_lines=True)
 lines = _t["lines"]
 
-# Recent activity summary uses just the last 50 lines (smaller dedup window
-# than tracking.sh's session_end summary — kept inline by design).
-# When `lines` is empty (fresh session before first assistant message) the
-# loop is a no-op and the script falls through to emit an "idle" heartbeat,
-# preserving liveness tracking.
+# Recent activity summary uses just the last 50 lines, with a tighter dedup
+# window (3) and looser text threshold (5) than tracking.sh's session_end
+# summary. When `lines` is empty (fresh session before first assistant
+# message) the helper returns ([], "") and we still emit an "idle" heartbeat
+# below, preserving liveness tracking.
 recent = lines[-50:] if len(lines) > 50 else lines
-tools_used = []
-last_text = ""
-for line in recent:
-    try:
-        entry = json.loads(line)
-        msg = entry.get("message", {})
-        if not isinstance(msg, dict):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, list):
-            for c in content:
-                if isinstance(c, dict):
-                    if c.get("type") == "tool_use":
-                        name = c.get("name", "")
-                        if name and name not in tools_used[-3:]:
-                            tools_used.append(name)
-                    if c.get("type") == "text" and msg.get("role") == "assistant":
-                        t = c.get("text", "").strip()
-                        if t and len(t) > 5:
-                            last_text = t[:100]
-    except:
-        continue
+tools_used, last_text = summarize_transcript_lines(
+    recent,
+    tools_dedup_window=3,
+    text_threshold=5,
+    text_truncate=100,
+)
 
 # Build short summary
 parts = []
@@ -131,7 +119,6 @@ if not model:
 model_family = infer_model_family(model, DEFAULT_FAMILY)
 cost_usd = calculate_cost(model_family, total_input, total_output, total_cache_creation, total_cache_read, PRICING)
 
-import urllib.request
 data = {
     "event": "heartbeat",
     "detail": detail,
@@ -152,36 +139,16 @@ data = {
 data = {k: v for k, v in data.items() if v is not None}
 payload = json.dumps(data).encode()
 
-debug_path = os.path.expanduser("~/.fyso/debug")
-log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-is_debug = os.path.exists(debug_path)
-
-if is_debug:
-    with open(log_path, "a") as dl:
-        dl.write(f"=== {datetime.datetime.utcnow().isoformat()}Z === EVENT=heartbeat ===\n")
-        dl.write(f"TRANSCRIPT: path={transcript} lines={len(lines)} model={model} session_tokens={total_tokens}\n")
-        dl.write(f"PAYLOAD: {payload.decode()}\n")
+if is_debug():
+    debug_log(f"=== {datetime.datetime.utcnow().isoformat()}Z === EVENT=heartbeat ===\n")
+    debug_log(f"TRANSCRIPT: path={transcript} lines={len(lines)} model={model} session_tokens={total_tokens}\n")
+    debug_log(f"PAYLOAD: {payload.decode()}\n")
 
 try:
-    req = urllib.request.Request(
-        f"{api_url}/api/entities/tracking/records",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "X-Tenant-ID": tenant,
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    resp = urllib.request.urlopen(req, timeout=5)
-    if is_debug:
-        resp_body = resp.read().decode()
-        with open(log_path, "a") as dl:
-            dl.write(f"RESPONSE: {resp.status} {resp_body[:200]}\n\n")
+    status, body = send_tracking_payload(api_url, token, tenant, payload)
+    debug_log(f"RESPONSE: {status} {body[:200]}\n\n")
 except Exception as e:
-    if is_debug:
-        with open(log_path, "a") as dl:
-            dl.write(f"ERROR: {e}\n\n")
+    debug_log(f"ERROR: {e}\n\n")
 PYEOF
 
 done

--- a/hooks/tracking.sh
+++ b/hooks/tracking.sh
@@ -16,7 +16,8 @@ cat > "$TMPFILE" 2>/dev/null || true
 
 EVENT_TYPE="${1:-session}"
 
-# Debug: save raw stdin for inspection
+# Debug: save raw stdin for inspection (mirrors _tracking_lib.is_debug/debug_log
+# but kept in bash so the cp + size measurement stay outside Python).
 if [ -f "$HOME/.fyso/debug" ]; then
   echo "=== $(date -u) === EVENT=$EVENT_TYPE ===" >> "$HOME/.fyso/hook-debug.log"
   cp "$TMPFILE" "$HOME/.fyso/last-hook-stdin-${EVENT_TYPE}.json" 2>/dev/null
@@ -27,24 +28,27 @@ fi
 # Single python call: read config + parse stdin + build payload + send
 export TMPFILE EVENT_TYPE PRICING_FILE FYSO_HOOKS_DIR="$SCRIPT_DIR"
 python3 << 'PYEOF'
-import json, re, datetime, os, sys, getpass, hashlib
-try:
-    import urllib.request
-except:
-    sys.exit(0)
+import json, datetime, os, sys, getpass, hashlib
 
-# Import shared tracking library (PRICING + infer_model_family + transcript parser)
+# Import shared tracking library (single source of truth for config/team/
+# transcript parsing/model family/HTTP send/debug logging).
 sys.path.insert(0, os.environ.get("FYSO_HOOKS_DIR", os.path.dirname(os.path.abspath(__file__))))
 try:
-    from _tracking_lib import load_pricing, infer_model_family, parse_transcript_usage
+    from _tracking_lib import (
+        load_pricing,
+        infer_model_family,
+        parse_transcript_usage,
+        summarize_transcript_lines,
+        load_config,
+        load_team_name,
+        debug_log,
+        send_tracking_payload,
+    )
 except Exception:
     sys.exit(0)
 
-config_path = os.path.expanduser("~/.fyso/config.json")
-try:
-    with open(config_path) as f:
-        cfg = json.load(f)
-except:
+cfg = load_config()
+if not cfg:
     sys.exit(0)
 
 token = cfg.get("token", "")
@@ -76,15 +80,8 @@ if tmpfile and os.path.exists(tmpfile):
             pass
 
 # Team info from local .fyso/team.json (per project directory)
-team_name = ""
 hook_cwd = hook.get("cwd", os.getcwd())
-try:
-    team_path = os.path.join(hook_cwd, ".fyso", "team.json")
-    if os.path.exists(team_path):
-        with open(team_path) as tf:
-            team_name = json.load(tf).get("team_name", "")
-except:
-    pass
+team_name = load_team_name(hook_cwd)
 
 event_type = os.environ.get("EVENT_TYPE", "session")
 
@@ -155,40 +152,24 @@ session_tokens = session_input + session_output + session_cache_creation + sessi
 if _t["model"]:
     model = _t["model"]
 _summary = ""
-_last_text = ""
 _tools_used = []
+_last_text = ""
 
-# Per-script summary pass (only for session_end/session_update) — distinct dedup
-# window and length thresholds vs heartbeat.sh, kept inline by design.
+# Per-script summary pass (only for session_end/session_update) — wider dedup
+# window (5) and stricter text threshold (10) than heartbeat.sh.
 if _needs_summary:
-    for raw_line in _t["lines"]:
-        try:
-            entry = json.loads(raw_line)
-        except:
-            continue
-        msg = entry.get("message", {})
-        if not isinstance(msg, dict):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, list):
-            for c in content:
-                if isinstance(c, dict):
-                    if c.get("type") == "tool_use":
-                        name = c.get("name", "")
-                        if name and name not in _tools_used[-5:]:
-                            _tools_used.append(name)
-                    if c.get("type") == "text" and msg.get("role") == "assistant":
-                        t = c.get("text", "").strip()
-                        if t and len(t) > 10:
-                            _last_text = t
+    _tools_used, _last_text = summarize_transcript_lines(
+        _t["lines"],
+        tools_dedup_window=5,
+        text_threshold=10,
+    )
 
-if transcript_path and os.path.exists(os.path.expanduser("~/.fyso/debug")):
-    log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-    try:
-        with open(log_path, "a") as dl:
-            dl.write(f"TRANSCRIPT: path={transcript_path} lines={_t['line_count']} usage_entries={_t['usage_count']} model_entries={_t['model_count']} model={model} session_tokens={session_tokens}\n")
-    except Exception:
-        pass
+if transcript_path:
+    debug_log(
+        f"TRANSCRIPT: path={transcript_path} lines={_t['line_count']} "
+        f"usage_entries={_t['usage_count']} model_entries={_t['model_count']} "
+        f"model={model} session_tokens={session_tokens}\n"
+    )
 
 # Fallback: default to opus (Claude Code default model)
 if not model:
@@ -242,35 +223,13 @@ data = {
 data = {k: v for k, v in data.items() if v is not None}
 payload = json.dumps(data).encode()
 
-# Debug: log payload
-debug_path = os.path.expanduser("~/.fyso/debug")
-if os.path.exists(debug_path):
-    log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-    with open(log_path, "a") as dl:
-        dl.write(f"PAYLOAD: {payload.decode()}\n")
+debug_log(f"PAYLOAD: {payload.decode()}\n")
 
-# Send
 try:
-    req = urllib.request.Request(
-        f"{api_url}/api/entities/tracking/records",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "X-Tenant-ID": tenant,
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    resp = urllib.request.urlopen(req, timeout=5)
-    resp_body = resp.read().decode()
-    if os.path.exists(debug_path):
-        with open(log_path, "a") as dl:
-            dl.write(f"RESPONSE: {resp.status} {resp_body[:200]}\n\n")
+    status, body = send_tracking_payload(api_url, token, tenant, payload)
+    debug_log(f"RESPONSE: {status} {body[:200]}\n\n")
 except Exception as e:
-    if os.path.exists(debug_path):
-        log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-        with open(log_path, "a") as dl:
-            dl.write(f"ERROR: {e}\n\n")
+    debug_log(f"ERROR: {e}\n\n")
 PYEOF
 
 # Cleanup


### PR DESCRIPTION
## Summary
- Adds `load_config`, `load_team_name`, `is_debug`, `debug_log`, `send_tracking_payload`, and `summarize_transcript_lines` to `hooks/_tracking_lib.py`.
- Replaces the inline duplicates in `tracking.sh` and `heartbeat.sh` with imports from the shared module. No behavioural changes: the summary helper is parameterized (dedup window, text threshold, optional truncate) so each script keeps its existing knobs.
- Removes the residual `urllib.request` boilerplate, debug-log open/write pairs, and config/team-json readers that were previously copy/pasted between the two scripts.

## Test plan
- [x] `npm test` in `opencode-plugin/` → 59/59 pass.
- [x] `bash -n` on both scripts.
- [x] `python3 -c "import ast; ast.parse(...)"` on `_tracking_lib.py` and on the heredoc-extracted Python of each script.
- [x] End-to-end smoke of `tracking.sh session_start` with a sandboxed `HOME=$tmp` containing a fake `~/.fyso/config.json` + `~/.fyso/debug` — payload built and `send_tracking_payload` invoked (connection refused as expected; debug log shows identical PAYLOAD shape to baseline).
- [x] Unit-checked `summarize_transcript_lines` on a synthetic JSONL slice for both parameter sets (tracking: dedup=5/threshold=10/no-truncate, heartbeat: dedup=3/threshold=5/truncate=100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)