### PR TITLE
security(hooks): stop interpolating tool input into PostToolUse shell

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'skills.*reference.*\\.md'; then bun \"${CLAUDE_PLUGIN_ROOT}/bin/sync-reference.ts\" 2>/dev/null; fi",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/sync-reference-trigger.sh",
             "timeout": 10000
           }
         ]

--- a/hooks/sync-reference-trigger.sh
+++ b/hooks/sync-reference-trigger.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Triggers sync-reference.ts when an Edit/Write tool touched
+# skills/<area>/reference/*.md.
+#
+# Reads the hook payload as JSON from stdin and parses it with python so
+# tool-input content is never interpolated into a shell command. The
+# previous inline hook used `echo "$CLAUDE_TOOL_INPUT"`, which exposed
+# the command to attacker-controlled $(...) / backtick expansion when
+# the hook framework substituted the placeholder before invoking bash.
+
+set -u
+
+INPUT="$(cat)"
+
+FILE_PATH="$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+ti = data.get("tool_input") if isinstance(data, dict) else None
+if not isinstance(ti, dict):
+    sys.exit(0)
+fp = ti.get("file_path", "")
+if isinstance(fp, str):
+    sys.stdout.write(fp)
+' 2>/dev/null)"
+
+case "$FILE_PATH" in
+  *skills/*/reference/*.md)
+    bun "${CLAUDE_PLUGIN_ROOT}/bin/sync-reference.ts" 2>/dev/null
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
- The PostToolUse hook for Edit|Write ran `echo "$CLAUDE_TOOL_INPUT" | grep ...` inline. If the hook framework substitutes `$CLAUDE_TOOL_INPUT` into the command string before invoking bash, an attacker-controlled `$(...)` or backtick payload inside file content reaches a shell parser and executes.
- Move the trigger to `hooks/sync-reference-trigger.sh`, which reads the hook payload as JSON from stdin and extracts `tool_input.file_path` with `python3`. The path is then matched with a `case` glob — never interpolated into a shell command.
- `hooks/hooks.json` now points the Edit|Write PostToolUse hook at the new script.

Closes #88

## Test plan
- [x] `tool_input.file_path = "$(touch /tmp/hook-injection-test)"` — no file created.
- [x] `tool_input.file_path = "\`touch /tmp/backtick-test\`"` — no file created.
- [x] `tool_input.file_path = "/project/skills/entity/reference/test.md"` — `bun .../bin/sync-reference.ts` is invoked.
- [x] Non-matching path (`/some/other/file.md`) — script exits without invoking bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)