### PR TITLE
refactor(hooks): extract config/HTTP/debug helpers into _tracking_lib

### DIFF
--- a/hooks/_tracking_lib.py
+++ b/hooks/_tracking_lib.py
@@ -7,6 +7,10 @@ Single source of truth for:
 - infer_model_family(model)
 - calculate_cost(family, ...)
 - parse_transcript_usage(path) — JSONL session token accumulator.
+- load_config() — reads ~/.fyso/config.json.
+- filter_payload(dict) — drops None-valued keys.
+- debug_enabled() / debug_log(msg) — ~/.fyso/debug flag + hook-debug.log.
+- send_tracking_event(api_url, token, tenant, payload) — POST to records API.
 
 The PRICING source-of-truth file can be overridden via the PRICING_FILE
 environment variable; otherwise it resolves relative to this file.
@@ -134,3 +138,66 @@ def parse_transcript_usage(transcript_path, retain_lines=False):
     except Exception:
         pass
     return result
+
+
+_DEBUG_FLAG_PATH = os.path.expanduser("~/.fyso/debug")
+_DEBUG_LOG_PATH = os.path.expanduser("~/.fyso/hook-debug.log")
+_CONFIG_PATH = os.path.expanduser("~/.fyso/config.json")
+_TRACKING_ENDPOINT = "/api/entities/tracking/records"
+
+
+def load_config(path=None):
+    """Return parsed ``~/.fyso/config.json`` dict, or ``None`` on missing/invalid file."""
+    try:
+        with open(path or _CONFIG_PATH) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def filter_payload(data):
+    """Drop keys whose value is ``None`` so the API receives only set fields."""
+    return {k: v for k, v in data.items() if v is not None}
+
+
+def debug_enabled():
+    """Return True when the user has touched ``~/.fyso/debug``."""
+    return os.path.exists(_DEBUG_FLAG_PATH)
+
+
+def debug_log(message):
+    """Append a line to ``~/.fyso/hook-debug.log`` iff debug is enabled.
+
+    Best-effort: silently swallows errors so debug logging never breaks a hook.
+    Caller is responsible for trailing newlines.
+    """
+    if not debug_enabled():
+        return
+    try:
+        with open(_DEBUG_LOG_PATH, "a") as dl:
+            dl.write(message)
+    except Exception:
+        pass
+
+
+def send_tracking_event(api_url, token, tenant, payload, timeout=5):
+    """POST ``payload`` (dict or bytes) to the tracking records endpoint.
+
+    Returns ``(status_code, response_body_text)``. Raises on network/HTTP errors
+    so the caller can decide whether to debug-log and swallow.
+    """
+    import urllib.request
+
+    body = json.dumps(payload).encode() if isinstance(payload, dict) else payload
+    req = urllib.request.Request(
+        f"{api_url.rstrip('/')}{_TRACKING_ENDPOINT}",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Tenant-ID": tenant,
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    return resp.status, resp.read().decode()

--- a/hooks/heartbeat.sh
+++ b/hooks/heartbeat.sh
@@ -35,17 +35,25 @@ while true; do
   python3 << 'PYEOF'
 import json, os, sys, datetime
 
-# Import shared tracking library (PRICING + infer_model_family + cost + transcript parser)
+# Import shared tracking library (config, pricing, model family, cost, transcript, HTTP)
 sys.path.insert(0, os.environ.get("FYSO_HOOKS_DIR", os.path.dirname(os.path.abspath(__file__))))
 try:
-    from _tracking_lib import load_pricing, infer_model_family, calculate_cost, parse_transcript_usage
+    from _tracking_lib import (
+        load_pricing,
+        infer_model_family,
+        calculate_cost,
+        parse_transcript_usage,
+        load_config,
+        filter_payload,
+        debug_log,
+        debug_enabled,
+        send_tracking_event,
+    )
 except Exception:
     sys.exit(0)
 
-config_path = os.path.expanduser("~/.fyso/config.json")
-try:
-    cfg = json.load(open(config_path))
-except:
+cfg = load_config()
+if cfg is None:
     sys.exit(0)
 
 token = cfg.get("token", "")
@@ -131,7 +139,6 @@ if not model:
 model_family = infer_model_family(model, DEFAULT_FAMILY)
 cost_usd = calculate_cost(model_family, total_input, total_output, total_cache_creation, total_cache_read, PRICING)
 
-import urllib.request
 data = {
     "event": "heartbeat",
     "detail": detail,
@@ -149,39 +156,19 @@ data = {
     "cwd": cwd or None,
     "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
 }
-data = {k: v for k, v in data.items() if v is not None}
+data = filter_payload(data)
 payload = json.dumps(data).encode()
 
-debug_path = os.path.expanduser("~/.fyso/debug")
-log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-is_debug = os.path.exists(debug_path)
-
-if is_debug:
-    with open(log_path, "a") as dl:
-        dl.write(f"=== {datetime.datetime.utcnow().isoformat()}Z === EVENT=heartbeat ===\n")
-        dl.write(f"TRANSCRIPT: path={transcript} lines={len(lines)} model={model} session_tokens={total_tokens}\n")
-        dl.write(f"PAYLOAD: {payload.decode()}\n")
+if debug_enabled():
+    debug_log(f"=== {datetime.datetime.utcnow().isoformat()}Z === EVENT=heartbeat ===\n")
+    debug_log(f"TRANSCRIPT: path={transcript} lines={len(lines)} model={model} session_tokens={total_tokens}\n")
+    debug_log(f"PAYLOAD: {payload.decode()}\n")
 
 try:
-    req = urllib.request.Request(
-        f"{api_url}/api/entities/tracking/records",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "X-Tenant-ID": tenant,
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    resp = urllib.request.urlopen(req, timeout=5)
-    if is_debug:
-        resp_body = resp.read().decode()
-        with open(log_path, "a") as dl:
-            dl.write(f"RESPONSE: {resp.status} {resp_body[:200]}\n\n")
+    status, body = send_tracking_event(api_url, token, tenant, payload)
+    debug_log(f"RESPONSE: {status} {body[:200]}\n\n")
 except Exception as e:
-    if is_debug:
-        with open(log_path, "a") as dl:
-            dl.write(f"ERROR: {e}\n\n")
+    debug_log(f"ERROR: {e}\n\n")
 PYEOF
 
 done

--- a/hooks/tracking.sh
+++ b/hooks/tracking.sh
@@ -28,23 +28,24 @@ fi
 export TMPFILE EVENT_TYPE PRICING_FILE FYSO_HOOKS_DIR="$SCRIPT_DIR"
 python3 << 'PYEOF'
 import json, re, datetime, os, sys, getpass, hashlib
-try:
-    import urllib.request
-except:
-    sys.exit(0)
 
-# Import shared tracking library (PRICING + infer_model_family + transcript parser)
+# Import shared tracking library (config, pricing, model family, transcript, HTTP)
 sys.path.insert(0, os.environ.get("FYSO_HOOKS_DIR", os.path.dirname(os.path.abspath(__file__))))
 try:
-    from _tracking_lib import load_pricing, infer_model_family, parse_transcript_usage
+    from _tracking_lib import (
+        load_pricing,
+        infer_model_family,
+        parse_transcript_usage,
+        load_config,
+        filter_payload,
+        debug_log,
+        send_tracking_event,
+    )
 except Exception:
     sys.exit(0)
 
-config_path = os.path.expanduser("~/.fyso/config.json")
-try:
-    with open(config_path) as f:
-        cfg = json.load(f)
-except:
+cfg = load_config()
+if cfg is None:
     sys.exit(0)
 
 token = cfg.get("token", "")
@@ -182,13 +183,8 @@ if _needs_summary:
                         if t and len(t) > 10:
                             _last_text = t
 
-if transcript_path and os.path.exists(os.path.expanduser("~/.fyso/debug")):
-    log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-    try:
-        with open(log_path, "a") as dl:
-            dl.write(f"TRANSCRIPT: path={transcript_path} lines={_t['line_count']} usage_entries={_t['usage_count']} model_entries={_t['model_count']} model={model} session_tokens={session_tokens}\n")
-    except Exception:
-        pass
+if transcript_path:
+    debug_log(f"TRANSCRIPT: path={transcript_path} lines={_t['line_count']} usage_entries={_t['usage_count']} model_entries={_t['model_count']} model={model} session_tokens={session_tokens}\n")
 
 # Fallback: default to opus (Claude Code default model)
 if not model:
@@ -239,38 +235,16 @@ data = {
     "cwd": hook.get("cwd", os.getcwd()) or None,
     "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
 }
-data = {k: v for k, v in data.items() if v is not None}
+data = filter_payload(data)
 payload = json.dumps(data).encode()
 
-# Debug: log payload
-debug_path = os.path.expanduser("~/.fyso/debug")
-if os.path.exists(debug_path):
-    log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-    with open(log_path, "a") as dl:
-        dl.write(f"PAYLOAD: {payload.decode()}\n")
+debug_log(f"PAYLOAD: {payload.decode()}\n")
 
-# Send
 try:
-    req = urllib.request.Request(
-        f"{api_url}/api/entities/tracking/records",
-        data=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "X-Tenant-ID": tenant,
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    resp = urllib.request.urlopen(req, timeout=5)
-    resp_body = resp.read().decode()
-    if os.path.exists(debug_path):
-        with open(log_path, "a") as dl:
-            dl.write(f"RESPONSE: {resp.status} {resp_body[:200]}\n\n")
+    status, body = send_tracking_event(api_url, token, tenant, payload)
+    debug_log(f"RESPONSE: {status} {body[:200]}\n\n")
 except Exception as e:
-    if os.path.exists(debug_path):
-        log_path = os.path.expanduser("~/.fyso/hook-debug.log")
-        with open(log_path, "a") as dl:
-            dl.write(f"ERROR: {e}\n\n")
+    debug_log(f"ERROR: {e}\n\n")
 PYEOF
 
 # Cleanup


### PR DESCRIPTION
## Summary
- Eliminate the final duplicated logic blocks between `hooks/tracking.sh` and `hooks/heartbeat.sh` by extending `hooks/_tracking_lib.py` with `load_config`, `filter_payload`, `debug_enabled`, `debug_log`, and `send_tracking_event`.
- Both hook scripts now import these helpers and drop the inline `urllib.request.Request` construction, repeated `os.path.exists("~/.fyso/debug")` checks, and per-script `open/write` debug-log boilerplate.
- Token accumulation, model-family inference, pricing load, and cost calc were already centralized in commit 60f7eff; this PR finishes the consolidation requested in the issue.

## Test plan
- [x] `npx vitest run` in `opencode-plugin/` — all 59 tests pass (TS-side untouched, but verified the shared TS `inferModelFamily` is still the source of truth and that pricing.json contract is unchanged).
- [x] Smoke-test the shared lib: import + exercise `infer_model_family`, `filter_payload`, `load_config`, `load_pricing` — all return expected shapes.
- [x] Compile-check the inline Python heredocs in `tracking.sh` and `heartbeat.sh` (`py_compile.compile` on the extracted heredoc bodies — clean).
- [x] End-to-end: ran `bash hooks/tracking.sh session_end` against a fake `~/.fyso/config.json`, fake JSONL transcript with sonnet usage, and `~/.fyso/debug` flag set. Debug log shows the expected TRANSCRIPT/PAYLOAD/ERROR lines with correct token breakdown (session_tokens=48), `model_family=sonnet`, and graceful failure on unreachable API.
- [x] End-to-end: ran the heartbeat inline Python body the same way with opus-family transcript usage. Got `model_family=opus`, `cost_usd=0.016628`, and properly-shaped payload.
- [ ] Recommended manual validation in CI / on a dev machine: enable `~/.fyso/debug`, run a short Claude Code session, confirm both heartbeat and tracking events fire identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)