### PR TITLE
fix(opencode-plugin): sync lockfile version with package.json (2.1.0)

### DIFF
--- a/opencode-plugin/package-lock.json
+++ b/opencode-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fyso/opencode-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fyso/opencode-plugin",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "bin": {
         "fyso-opencode-setup": "src/setup.ts"


### PR DESCRIPTION
## Summary
- `opencode-plugin/package-lock.json` still referenced version `2.0.0` after the 2.1.0 bump, causing `npm ci` to fail the lockfile sync check.
- Updated both the top-level and `packages.""` `version` fields to `2.1.0` so reproducible installs work again.

## Test plan
- [x] `cd opencode-plugin && npm ci` completes without errors
- [x] `git diff opencode-plugin/package-lock.json` shows only the two version fields changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)